### PR TITLE
Fix pagination and make org a parameter

### DIFF
--- a/gh-cli/get-repos-using-actions.sh
+++ b/gh-cli/get-repos-using-actions.sh
@@ -1,6 +1,14 @@
 #!/bin/bash
 
-gh api graphql --paginate -F owner='joshjohanning-org' -f query='
+if [ -z "$1" ]
+  then
+    echo "Usage: $0 <org>"
+    exit 1
+fi
+
+org=$1
+
+gh api graphql --paginate -F owner="$org" -f query='
   query ($owner: String!, $endCursor: String = null) {
     organization(login: $owner) {
       repositories(
@@ -9,6 +17,7 @@ gh api graphql --paginate -F owner='joshjohanning-org' -f query='
         after: $endCursor
       ) {
         totalCount
+        pageInfo {hasNextPage endCursor}
         nodes {
           name
           object(expression: "HEAD:.github/workflows/") {


### PR DESCRIPTION
The pagination was broken since `pageInfo` is missing

Made org name an parameter instead of being hardcoded