### PR TITLE
Add script to get list of repo webhooks in a given org

### DIFF
--- a/gh-cli/README.md
+++ b/gh-cli/README.md
@@ -466,3 +466,16 @@ Updates a branch protection rule for a given branch.
 ## update-enterprise-owner-organizational-role.sh
 
 Adds your account to an organization in an enterprise as an owner, member, or leave the organization.
+
+## get-repositories-webhooks-csv.sh
+
+Gets a CSV with the list of repository webhooks in a GitHub organization.
+
+Generates a CSV with 4 columns:
+
+- repo name - The repository name
+- is active - If the webhook is active or not
+- webhook url - The url of the weehook
+- secret - Webhook secret, it will be masked since the API doesn't return the actual secret.
+
+This script is useful when doing migrations, to determine the kind of actions that might be needed based on the webhooks inventory.

--- a/gh-cli/get-repositories-webhooks-csv.sh
+++ b/gh-cli/get-repositories-webhooks-csv.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+if [ $# -ne 1 ]
+  then
+    echo "usage: $0 <org>"
+    exit 1
+fi
+org=$1
+export PAGER=""
+gh api "orgs/$org/repos" --paginate --jq .[].name | while read -r repo; 
+do
+    gh api "repos/$org/$repo/hooks" | jq -r --arg repo "$repo" '.[] | [$repo,.active,.config.url, .config.secret] | @tsv'
+done


### PR DESCRIPTION
Add `get-repositories-webhooks-csv.sh` script

Gets a CSV with the list of repository webhooks in a GitHub organization.

Generates a CSV with 4 columns:

- repo name - The repository name
- is active - If the webhook is active or not
- webhook url - The url of the weehook
- secret - Webhook secret, it will be masked since the API doesn't return the actual secret.

This script is useful when doing migrations, to determine the kind of actions that might be needed based on the webhooks inventory.
