### PR TITLE
Parameterize add team repository

### DIFF
--- a/gh-cli/add-team-to-repository.sh
+++ b/gh-cli/add-team-to-repository.sh
@@ -1,3 +1,32 @@
 #!/bin/bash
 
-gh api --method PUT /orgs/joshjohanning-org/teams/my-team/repos/joshjohanning-org/my-repo -f permission='push'
+permissions=("pull" "triage" "push" "maintain" "admin")
+
+if [ $# -ne 4 ]
+  then
+    echo "usage: $0 <org> <repo> <team slug> <permission>"
+    echo "permission can be one of: ${permissions[*]}"
+    exit 1
+fi
+
+org=$1
+repo=$2
+team=$3
+permission=$4
+
+if [[ ! " ${permissions[*]} " =~  ${permission}  ]]
+  then
+    echo "permission must be one of: ${permissions[*]}"
+    exit 1
+fi
+
+
+if [ "$permission" != "pull" ] &&  [ "$permission" != "triage" ] && [ "$permission" != "push" ] && [ "$permission" != "mantain" ] && [ "$permission" != "admin" ]
+  then
+    echo "permission must be one of following values: ${permissions[*]}"
+    exit 1
+fi
+
+# https://docs.github.com/en/rest/teams/teams?apiVersion=2022-11-28#add-or-update-team-repository-permissions
+
+gh api --method PUT "/orgs/$org/teams/$team/repos/$org/$repo" -f permission="$permission"


### PR DESCRIPTION
Add parameters to add-team-to-repository.sh script

The sample had hardcoded values, now everything is a parameter:

- Org
- Repo
- Team Slug
- Permission