### PR TITLE
Parameterize get-enterprise-organizations

### DIFF
--- a/gh-cli/README.md
+++ b/gh-cli/README.md
@@ -188,7 +188,13 @@ See the [docs](https://docs.github.com/en/graphql/reference/objects#enterpriseow
 
 ## get-enterprise-organizations.sh
 
-Gets all organizations for a given enterprise. Handles pagination.
+Gets all organizations for a given enterprise, requires the enterprise slug. Handles pagination and returns the organization id and login.
+
+To get the list of all org names you can use `jq` to parse the JSON output:
+
+```shell
+./get-enterprise-organizations.sh octocat-corp | jq -r '.data.enterprise.organizations.nodes[].login'
+```
 
 ## get-enterprise-roles-in-organizations-all-roles.sh
 

--- a/gh-cli/get-enterprise-organizations.sh
+++ b/gh-cli/get-enterprise-organizations.sh
@@ -1,6 +1,13 @@
 #!/bin/bash
 
-gh api graphql --paginate -f enterpriseName='my-enterprise-name' -f query='
+if [ -z "$1" ]; then
+  echo "Usage: $(basename $0) <enterprise-slug>"
+  exit 1
+fi
+
+enterpriseslug=$1
+
+gh api graphql --paginate -f enterpriseName="$enterpriseslug" -f query='
 query getEnterpriseOrganizations($enterpriseName: String! $endCursor: String) {
   enterprise(slug: $enterpriseName) {
     organizations(first: 100, after: $endCursor) {


### PR DESCRIPTION
enterprise slug is no longer hardcoded and can now be passed as a parameter