### PR TITLE
Add copy-permissions-between-org-repos script

### DIFF
--- a/gh-cli/README.md
+++ b/gh-cli/README.md
@@ -484,6 +484,8 @@ This script is useful when doing migrations, to determine the kind of actions th
 
 Copy user and team repository member permissions to another repository (it can be in the same or on different organizations).
 
+External collaborators are not copied intentionally.
+
 If the team on the target organization doesn't exist, one will be created (same name, description, privacy and notification settings ONLY).
 
 > **Note:** The created team will not be a full copy, **Only** name and description are honored. If the team is part of a child/parent relantionship, or it's associated with an IDP group it will not be honored. If you want to change this behavior, you can modify the `createTeamIfNotExists` function.

--- a/gh-cli/README.md
+++ b/gh-cli/README.md
@@ -479,3 +479,25 @@ Generates a CSV with 4 columns:
 - secret - Webhook secret, it will be masked since the API doesn't return the actual secret.
 
 This script is useful when doing migrations, to determine the kind of actions that might be needed based on the webhooks inventory.
+
+## copy-permissions-between-org-repos.sh
+
+Copy user and team repository member permissions to another repository (it can be in the same or on different organizations).
+
+If the team on the target organization doesn't exist, one will be created (same name, description, privacy and notification settings ONLY).
+
+> **Note:** The created team will not be a full copy, **Only** name and description are honored. If the team is part of a child/parent relantionship, or it's associated with an IDP group it will not be honored. If you want to change this behavior, you can modify the `createTeamIfNotExists` function.
+
+This script requires 2 environment variables (with another optional one):
+
+- SOURCE_TOKEN - A GitHub Token to access data from the source organization. Requires org:read and repo scopes.
+- TARGET_TOKEN - A GitHub Token to set data on the target organization. Requires org:admin and repo scopes.
+- MAP_USER_SCRIPT - path to a script to map user login. This is optional, if you set this environment value it will call the script to map user logins before adding them on the target repo. The script will receive the user login as the first argument and it should return the new login. For example, if you want to add a suffix to the user login:
+
+```shell
+#!/bin/bash
+
+echo "$1"_SHORTCODE
+```
+
+You can have more complex mappings this just a basic example, where a copy is being done between a GHEC and a GHEC EMU instance where the logins are going to be exactly the same, but the EMU instance has a suffix on the logins.

--- a/gh-cli/README.md
+++ b/gh-cli/README.md
@@ -35,6 +35,10 @@ Adds a status check to the branch protection status check contexts.
 
 See the [docs](https://docs.github.com/en/rest/branches/branch-protection?apiVersion=2022-11-28#add-status-check-contexts) for more information.
 
+## add-collaborator-to-repository.sh
+
+Adds a user with a specified role to a repository. Used in the `./copy-permissions-between-org-repos.sh` script.
+
 ## add-enterprise-organization-member.sh
 
 Adds a user from an Enterprise into an org. See: [Documentation](https://docs.github.com/en/graphql/reference/mutations#addenterpriseorganizationmember)
@@ -70,6 +74,30 @@ Creates an organization webhook, with a secret, with some help from `jq`.
 ## create-repository-from-template.sh
 
 Create a new repo from a repo template - note that it only creates as public or private, if you want internal you have to do a subsequent call (see `change-repository-visibility.sh`)
+
+## copy-permissions-between-org-repos.sh
+
+Copy user and team repository member permissions to another repository (it can be in the same or on different organizations).
+
+External collaborators are not copied intentionally.
+
+If the team on the target organization doesn't exist, one will be created (same name, description, privacy, and notification settings ONLY).
+
+> **Note:** The created team will not be a full copy, **Only** name and description are honored. If the team is part of a child/parent relationship, or it's associated with an IDP group it will not be honored. If you want to change this behavior, you can modify the `createTeamIfNotExists` function.
+
+This script requires 2 environment variables (with another optional one):
+
+- SOURCE_TOKEN - A GitHub Token to access data from the source organization. Requires `org:read` and `repo` scopes.
+- TARGET_TOKEN - A GitHub Token to set data on the target organization. Requires `org:admin` and `repo` scopes.
+- MAP_USER_SCRIPT - path to a script to map user login. This is optional, if you set this environment value it will call the script to map user logins before adding them on the target repo. The script will receive the user login as the first argument and it should return the new login. For example, if you want to add a suffix to the user login:
+
+```shell
+#!/bin/bash
+
+echo "$1"_SHORTCODE
+```
+
+You can have more complex mappings this just a basic example, where a copy is being done between a GHEC and a GHEC EMU instance where the logins are going to be exactly the same, but the EMU instance has a suffix on the logins.
 
 ## delete-release.sh
 
@@ -328,10 +356,6 @@ Get the repository license information (ie: MIT, Apache 2.0, etc) for all reposi
 
 Gets a list of topics for a repository
 
-## get-repository.sh
-
-Gets details about a repo
-
 ## get-repository-users-by-permission-for-organization.sh
 
 Similar to `get-repository-users-by-permission.sh` except that it loops through all repositories. See the below note about cumulative permissions; if you query for `push` you will also get users for `maintain` and `admin`, but you can pass in a `false` and retrieve only users who have `push`.
@@ -361,6 +385,23 @@ joshjohanning,admin
 ## get-repository-users-permission-and-source.sh
 
 Returns the permission for everyone who can access the repo and how they access it (direct, team, org)
+
+## get-repositories-webhooks-csv.sh
+
+Gets a CSV with the list of repository webhooks in a GitHub organization.
+
+Generates a CSV with 4 columns:
+
+- repo name - The repository name
+- is active - If the webhook is active or not
+- webhook url - The url of the weehook
+- secret - Webhook secret, it will be masked since the API doesn't return the actual secret.
+
+This script is useful when doing migrations, to determine the kind of actions that might be needed based on the webhooks inventory.
+
+## get-repository.sh
+
+Gets details about a repo
 
 ## get-saml-identities-in-enterprise.sh
 
@@ -466,40 +507,3 @@ Updates a branch protection rule for a given branch.
 ## update-enterprise-owner-organizational-role.sh
 
 Adds your account to an organization in an enterprise as an owner, member, or leave the organization.
-
-## get-repositories-webhooks-csv.sh
-
-Gets a CSV with the list of repository webhooks in a GitHub organization.
-
-Generates a CSV with 4 columns:
-
-- repo name - The repository name
-- is active - If the webhook is active or not
-- webhook url - The url of the weehook
-- secret - Webhook secret, it will be masked since the API doesn't return the actual secret.
-
-This script is useful when doing migrations, to determine the kind of actions that might be needed based on the webhooks inventory.
-
-## copy-permissions-between-org-repos.sh
-
-Copy user and team repository member permissions to another repository (it can be in the same or on different organizations).
-
-External collaborators are not copied intentionally.
-
-If the team on the target organization doesn't exist, one will be created (same name, description, privacy and notification settings ONLY).
-
-> **Note:** The created team will not be a full copy, **Only** name and description are honored. If the team is part of a child/parent relantionship, or it's associated with an IDP group it will not be honored. If you want to change this behavior, you can modify the `createTeamIfNotExists` function.
-
-This script requires 2 environment variables (with another optional one):
-
-- SOURCE_TOKEN - A GitHub Token to access data from the source organization. Requires org:read and repo scopes.
-- TARGET_TOKEN - A GitHub Token to set data on the target organization. Requires org:admin and repo scopes.
-- MAP_USER_SCRIPT - path to a script to map user login. This is optional, if you set this environment value it will call the script to map user logins before adding them on the target repo. The script will receive the user login as the first argument and it should return the new login. For example, if you want to add a suffix to the user login:
-
-```shell
-#!/bin/bash
-
-echo "$1"_SHORTCODE
-```
-
-You can have more complex mappings this just a basic example, where a copy is being done between a GHEC and a GHEC EMU instance where the logins are going to be exactly the same, but the EMU instance has a suffix on the logins.

--- a/gh-cli/add-collaborator-to-repository.sh
+++ b/gh-cli/add-collaborator-to-repository.sh
@@ -20,4 +20,4 @@ if [[ ! " ${permissions[*]} " =~  ${role}  ]]
 fi
 
 # https://docs.github.com/en/rest/collaborators/collaborators?apiVersion=2022-11-28#add-a-repository-collaborator
-gh api --method PUT "/repos/$org/$repo/collaborators/$login" -f permission="$role"
+gh api --method PUT "repos/$org/$repo/collaborators/$login" -f permission="$role"

--- a/gh-cli/add-collaborator-to-repository.sh
+++ b/gh-cli/add-collaborator-to-repository.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+permissions=("pull" "triage" "push" "maintain" "admin")
+
+if [ $# -ne 4 ]
+  then
+    echo "usage: $(basename $0) <org> <repo> <login> <role>"
+    exit 1
+fi
+
+org=$1
+repo=$2
+login=$3
+role=$4
+
+if [[ ! " ${permissions[*]} " =~  ${role}  ]]
+  then
+    echo "permission must be one of: ${permissions[*]}"
+    exit 1
+fi
+
+# https://docs.github.com/en/rest/collaborators/collaborators?apiVersion=2022-11-28#add-a-repository-collaborator
+gh api --method PUT "/repos/$org/$repo/collaborators/$login" -f permission="$role"

--- a/gh-cli/add-team-to-repository.sh
+++ b/gh-cli/add-team-to-repository.sh
@@ -20,13 +20,6 @@ if [[ ! " ${permissions[*]} " =~  ${permission}  ]]
     exit 1
 fi
 
-
-if [ "$permission" != "pull" ] &&  [ "$permission" != "triage" ] && [ "$permission" != "push" ] && [ "$permission" != "mantain" ] && [ "$permission" != "admin" ]
-  then
-    echo "permission must be one of following values: ${permissions[*]}"
-    exit 1
-fi
-
 # https://docs.github.com/en/rest/teams/teams?apiVersion=2022-11-28#add-or-update-team-repository-permissions
 
 gh api --method PUT "/orgs/$org/teams/$team/repos/$org/$repo" -f permission="$permission"

--- a/gh-cli/add-team-to-repository.sh
+++ b/gh-cli/add-team-to-repository.sh
@@ -22,4 +22,4 @@ fi
 
 # https://docs.github.com/en/rest/teams/teams?apiVersion=2022-11-28#add-or-update-team-repository-permissions
 
-gh api --method PUT "/orgs/$org/teams/$team/repos/$org/$repo" -f permission="$permission"
+gh api --method PUT "orgs/$org/teams/$team/repos/$org/$repo" -f permission="$permission"

--- a/gh-cli/copy-permissions-between-org-repos.sh
+++ b/gh-cli/copy-permissions-between-org-repos.sh
@@ -77,7 +77,7 @@ GH_TOKEN=$SOURCE_TOKEN gh api "repos/$source_org/$repo/collaborators?affiliation
 
     echo "Adding user: $login with $role to $target_org/$target_repo"
 
-    ./add-collaborator-to-repository.sh "$target_org" "$target_repo" "$login" "$role"
+    GH_TOKEN=$TARGET_TOKEN ./add-collaborator-to-repository.sh "$target_org" "$target_repo" "$login" "$role"
 done
 
 echo -e "\nGranting Permissions to teams:\n"

--- a/gh-cli/copy-permissions-between-org-repos.sh
+++ b/gh-cli/copy-permissions-between-org-repos.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+
+if [ $# -ne 4 ]
+  then
+    echo "usage: $0 <source org> <repo> <target org> [target repo]"
+    echo "If target repo is skipped the name will be same as the source repo"
+    exit 1
+fi
+
+if [ -z "$SOURCE_TOKEN" ]
+  then
+    echo "SOURCE_TOKEN must be set"
+    exit 1
+fi
+
+if [ -z "$TARGET_TOKEN" ]
+  then
+    echo "TARGET_TOKEN must be set"
+    exit 1
+fi
+
+source_org=$1
+repo=$2
+target_org=$3
+target_repo=${4:-$repo}
+
+if [ -z "$MAP_USER_SCRIPT" ]; then
+    echo "WARNING: MAP_USER_SCRIPT is not set. No mapping will be performed."
+    echo "Add a script to the environment variable MAP_USER_SCRIPT to map users from $source_org to $target_org"
+  else
+    if [ ! -f "$MAP_USER_SCRIPT" ]; then
+        echo "MAP_USER_SCRIPT is set to $MAP_USER_SCRIPT"
+        echo "ERROR: MAP_USER_SCRIPT is not a file"
+        exit 1
+    fi
+fi
+
+function map_role() {
+    role=$1
+    if [ "$role" = "write" ]; then
+        echo "push"
+    elif [ "$role" = "read" ]; then
+        echo "pull"
+    else
+        echo "$role"    
+    fi
+}
+
+function createTeamIfNotExists() {
+    source_org=$1
+    target_org=$2
+    slug=$3
+
+    # https://docs.github.com/en/rest/teams/teams?apiVersion=2022-11-28#get-a-team-by-name
+    GH_TOKEN=$TARGET_TOKEN gh api "orgs/$target_org/teams/$slug" --silent
+    if [ $? != 0  ]; then
+        JSON=$(GH_TOKEN=$SOURCE_TOKEN gh api "orgs/$source_org/teams/$slug" --jq '{name, description, privacy,notification_setting}')
+
+        # https://docs.github.com/en/rest/teams/teams?apiVersion=2022-11-28#create-a-team
+        GH_TOKEN=$TARGET_TOKEN gh api --method POST "orgs/$target_org/teams" --input - <<< "$JSON" --silent
+
+        # Remove us from the team, so the team is empty
+        ghuser=$(GH_TOKEN=$TARGET_TOKEN gh api user --jq '.login')
+        GH_TOKEN=$TARGET_TOKEN gh api --method DELETE  "orgs/$target_org/teams/$slug/memberships/$ghuser" --silent
+
+    fi
+}
+
+echo -e "\nGranting Permissions to users:\n"
+
+GH_TOKEN=$SOURCE_TOKEN gh api "repos/$source_org/$repo/collaborators?affiliation=direct" --jq '.[] | [.login,.role_name] | @tsv' | while read -r login role; do
+    if [ -n "$MAP_USER_SCRIPT" ]; then
+        login=$($MAP_USER_SCRIPT "$login")
+    fi
+
+    role=$(map_role "$role")
+
+    echo "Adding user: $login with $role to $target_org/$target_repo"
+
+    ./add-collaborator-to-repository.sh "$target_org" "$target_repo" "$login" "$role"
+done
+
+echo -e "\nGranting Permissions to teams:\n"
+GH_TOKEN=$SOURCE_TOKEN gh api "repos/$source_org/$repo/teams" --jq '.[] | [.name,.slug,.permission] | @tsv' | while IFS=$'\t' read -r -a fields; do
+    name=${fields[0]}
+    slug=${fields[1]}
+    permission=${fields[2]}
+    echo "Adding team: [$name] ($slug) with $permission to $target_org/$target_repo"
+
+    createTeamIfNotExists "$source_org" "$target_org" "$slug"
+
+    GH_TOKEN=$TARGET_TOKEN ./add-team-to-repository.sh "$target_org" "$target_repo" "$slug" "$permission"
+done
+
+echo -e "\n"
+


### PR DESCRIPTION
Copies user and teams membership between different repos (same or different org)

If the team doesn't exist create it (note: Doesn't recreate all team attributes)