### PR TITLE
Add copy-organization-team-members.sh and copy-team-members.sh

### DIFF
--- a/gh-cli/README.md
+++ b/gh-cli/README.md
@@ -96,6 +96,52 @@ FluffyCarlton
 
 ```
 
+## copy-organization-team-members.sh
+
+Copy organization team members from one organization to the other, the member will **retain** the source role (maintainer, member).
+
+It copies the members of team members of teams in the source organization but only for teams that also exist in the target organization.
+
+This script requires 2 environment variables (with another optional one):
+
+- SOURCE_TOKEN - A GitHub Token to access data from the source organization. Requires `org:read` scopes.
+- TARGET_TOKEN - A GitHub Token to set data on the target organization. Requires `org:admin` and `repo` scopes.
+- MAP_USER_SCRIPT - path to a script to map user login. This is optional, if you set this environment value it will call the script to map user logins before adding them on the target repo. The script will receive the user login as the first argument and it should return the new login. For example, if you want to add a suffix to the user login:
+
+```shell
+#!/bin/bash
+
+echo "$1"_SHORTCODE
+```
+
+You can have more complex mappings this just a basic example, where a copy is being done between a GHEC and a GHEC EMU instance where the logins are going to be exactly the same, but the EMU instance has a suffix on the logins.
+
+> **Warning** If users are not members of the target organizations they will not be added to the target team but may receive an invite to join the org.
+
+## copy-team-members.sh
+
+Copy team member from one team to another, it respect source role type (maintainer, member).
+
+> **Note** Only direct members are copied, child team members are not copied.
+
+If the target team already has user they will be preserved, this **doesn't** synch members between teams, it merely copies them. If you want a synch then you need to delete the existem team members in the target team before running this script.
+
+This script requires 2 environment variables (with another optional one):
+
+- SOURCE_TOKEN - A GitHub Token to access data from the source organization. Requires `org:read` scopes.
+- TARGET_TOKEN - A GitHub Token to set data on the target organization. Requires `org:admin` and `repo` scopes.
+- MAP_USER_SCRIPT - path to a script to map user login. This is optional, if you set this environment value it will call the script to map user logins before adding them on the target repo. The script will receive the user login as the first argument and it should return the new login. For example, if you want to add a suffix to the user login:
+
+```shell
+#!/bin/bash
+
+echo "$1"_SHORTCODE
+```
+
+You can have more complex mappings this just a basic example, where a copy is being done between a GHEC and a GHEC EMU instance where the logins are going to be exactly the same, but the EMU instance has a suffix on the logins.
+
+> **Warning** If users are not members of the target organizations they will not be added to the target team but may receive an invite to join the org.
+
 ## change-repository-visibility.sh
 
 Change a repository visibility to internal, for example

--- a/gh-cli/copy-organization-team-members.sh
+++ b/gh-cli/copy-organization-team-members.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+script_path=$(dirname $0)
+
+if [ $# -ne 2 ]
+  then
+    echo "usage: $0 <source org> <target org>"
+    exit 1
+fi
+
+if [ -z "$SOURCE_TOKEN" ]
+  then
+    echo "SOURCE_TOKEN must be set"
+    exit 1
+fi
+
+if [ -z "$TARGET_TOKEN" ]
+  then
+    echo "TARGET_TOKEN must be set"
+    exit 1
+fi
+
+source_org=$1
+target_org=$2
+
+if [ "$source_org" = "$target_org" ]
+  then
+    echo "source org and target org must be different"
+    exit 1
+fi
+
+# read all target teams and loops
+GH_TOKEN=$TARGET_TOKEN gh api "orgs/$target_org/teams" --jq '.[].slug' | while read -r slug; do
+  # check if team exists at source
+  if ! GH_TOKEN=$SOURCE_TOKEN gh api "orgs/$source_org/teams/$slug" --silent ; then 
+    echo "Team $slug does not exist at source. Skipping"
+  else
+    echo "Copying team $slug from $source_org to $target_org"
+    "$script_path/copy-team-members.sh" "$source_org" "$slug" "$target_org" "$slug"
+  fi
+done

--- a/gh-cli/copy-team-members.sh
+++ b/gh-cli/copy-team-members.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+if [ $# -lt 3 ]; then
+    echo "Usage: $0 <source org> <source team> <target org> [target team]"
+    exit 1
+fi
+
+if [ -z "$SOURCE_TOKEN" ]; then
+    echo "SOURCE_TOKEN must be set"
+    exit 1
+fi
+
+if [ -z "$TARGET_TOKEN" ]; then
+    echo "TARGET_TOKEN must be set"
+    exit 1
+fi
+
+source_org=$1
+source_team=$2
+target_org=$3
+target_team=${4:-$source_team}
+
+# Check if target team exists
+if ! GH_TOKEN=$TARGET_TOKEN gh api --silent "/orgs/$target_org/teams/$target_team" > /dev/null 2>&1; then
+    echo "Error: Target team $target_org/$target_team does not exist"
+    exit 1
+fi
+
+if [ -z "$MAP_USER_SCRIPT" ]; then
+    echo "WARNING: MAP_USER_SCRIPT is not set. No mapping will be performed."
+    echo "Add a script to the environment variable MAP_USER_SCRIPT to map users from $source_org to $target_org"
+else
+    if [ ! -f "$MAP_USER_SCRIPT" ]; then
+        echo "MAP_USER_SCRIPT is set to $MAP_USER_SCRIPT"
+        echo "ERROR: MAP_USER_SCRIPT is not a file"
+        exit 1
+    fi
+fi
+
+echo -e "\ncopying members from $source_org/$source_team to $target_org/$target_team\n"
+
+GH_TOKEN=$SOURCE_TOKEN gh api graphql -f org="$source_org" -f teamslug="$source_team" -F query='query($org:String! $teamslug:String! $cursor:String) {
+  organization(login: $org) {
+    team(slug: $teamslug) {
+      members(first: 100, after:$cursor, membership: IMMEDIATE) {
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+        edges {
+          node {
+            login
+          }
+          role
+        }
+      }
+    }
+  }
+}' --jq '.data.organization.team.members.edges[] | [.node.login, .role] | @tsv' | while read -r login role; do
+
+    if [ -n "$MAP_USER_SCRIPT" ]; then
+        login=$($MAP_USER_SCRIPT "$login")
+    fi
+
+    role=$(echo "$role" | tr '[:upper:]' '[:lower:]')
+    echo "  Adding $login with role $role to $target_org/$target_team"
+    if ! GH_TOKEN=$TARGET_TOKEN gh api --silent --method PUT "/orgs/$target_org/teams/$target_team/memberships/$login" -f role="$role" ; then
+        echo "  Error adding $login to $target_org/$target_team"
+    fi
+done
+


### PR DESCRIPTION
`copy-team-members.sh` copies user members from one organization to the other. It only copies members doesn't delete existing members at target org.

`copy-organization-team-members.sh` Copies members from all teams that exist on the target org and also exist at the source. It calls `copy-team-members.sh` to do the actual copy, so same semantics apply.