### PR TITLE
Updating IP allow list script to support enterprises

### DIFF
--- a/gh-cli/README.md
+++ b/gh-cli/README.md
@@ -774,16 +774,9 @@ Set the branch protection status check contexts.
 
 See the [docs](https://docs.github.com/en/rest/branches/branch-protection?apiVersion=2022-11-28#set-status-check-contexts) for more information.
 
-## set-ip-allow-list-setting.sh
+## set-ip-allow-list-rules.sh
 
-Sets the IP allow list to enabled/disable for an enterprise or organization. You can't enable the IP allow list unless the IP running the script is in the list.
-
-See the [docs](https://docs.github.com/en/graphql/reference/mutations#updateipallowlistenabledsetting) for further information.
-
-## set-org-ip-allow-list-rules.sh
-
-```suggestion
-Sets the IP allow list rules for an organization from a set of rules defined in a file. The script is idempotent; running it multiple times will only make the changes needed to match the rules in the file.
+Sets the IP allow list rules for an enterprise or organization from a set of rules defined in a file. The script is idempotent; running it multiple times will only make the changes needed to match the rules in the file.
 
 In order to ensure availability of the service, the script first adds all necessary rules and only after that will delete rules no longer applicable. This ensures no disruption of service if the change has an (partial) overlapping set of rules.
 
@@ -797,28 +790,34 @@ This script requires `org:admin` scope.
 The file with the rules should be in the following format:
 
 ```json
- {
-     "list": [
-         {
-             "name": "proxy-us",
-             "ip": "192.168.1.1"
-         },
-         {
-             "name": "proxy-us",
-             "ip": "192.168.1.2"
-         },
-         {
-             "name": "proxy-eu",
-             "ip": "192.168.88.0/23"
-         }
-     ]
- }
+{
+    "list": [
+        {
+            "name": "proxy-us",
+            "ip": "192.168.1.1"
+        },
+        {
+            "name": "proxy-us",
+            "ip": "192.168.1.2"
+        },
+        {
+            "name": "proxy-eu",
+            "ip": "192.168.88.0/23"
+        }
+    ]
+}
 ```
 
 > **Note**
 > The script logic is independent of the rules format since the file is normalized before comparisons are performed. If you want to use a different format, a surgical change to the rules normalization can be made (see script source code,search for `CUSTOMIZE` keyword)
 
 Run the script in `dry-run` to get a preview of the changes without actually applying them.
+
+## set-ip-allow-list-setting.sh
+
+Sets the IP allow list to enabled/disable for an enterprise or organization. You can't enable the IP allow list unless the IP running the script is in the list.
+
+See the [docs](https://docs.github.com/en/graphql/reference/mutations#updateipallowlistenabledsetting) for further information.
 
 ## update-branch-protection-rule.sh
 

--- a/gh-cli/set-ip-allow-list-rules.sh
+++ b/gh-cli/set-ip-allow-list-rules.sh
@@ -75,7 +75,6 @@ Example:
   ./set-ip-allow-list-setting.sh --enterprise fabrikam-enterprise -r rules.json --dry-run
 
 EOM
-  exit 1
 }
 
 ####################################
@@ -86,6 +85,7 @@ while (( "$#" )); do
   case "$1" in
     -h|--help)
       PrintUsage;
+      exit 0;
       ;;
     --org)
       organization_name=$2
@@ -124,6 +124,7 @@ done
 
 if [ -z "$rules_file" ] || { [ "$organization_name" ] && [ "$enterprise_name" ]; } || { [ -z "$organization_name" ] && [ -z "$enterprise_name" ]; }; then
   PrintUsage
+  exit 1
 fi
 
 # check if file exists


### PR DESCRIPTION


cc @tspascoal - slightly more involved than I thought since GraphQL for _getting_ IP allow lists between org and enterprise is different.  Setting/removing is the same, though. 

What do you think? 

Seems to work though! 

```
./set-ip-allow-list-rules.sh --enterprise my-enterprise --rules-file ip-allow-rules.json --dry-run

Running in dry-run mode. No changes will be made

Current number of rules in my-enterprise: 5
Number of rules in ip-allow-rules.json: 3

Checking new or updated rules to add
  Adding rule: proxy-eu with value: 192.168.88.0/23
  Adding rule: proxy-us with value: 192.168.1.1
  Adding rule: proxy-us with value: 192.168.1.2

Checking rules no longer relevant for deletion
  Deleting rule:  with value: 1.2.3.4 with id: IALE_kwDNCRTOAA1Hew
  Deleting rule: josh with value: 1.2.3.5 with id: IALE_kwDNCRTOAA1IhA
  Deleting rule: test ip with value: 1.2.3.6 with id: IALE_kwDNCRTOAA2Hvg
  Deleting rule: test with value: 1.2.3.7 with id: IALE_kwDNCRTOAA1Igw
  Deleting rule: test with value: 1.2.3.8 with id: IALE_kwDNCRTOAA2Obw

Done
```

```
./set-ip-allow-list-rules.sh --org my-org --rules-file ip-allow-rules.json --dry-run

Running in dry-run mode. No changes will be made

Current number of rules in my-org: 2
Number of rules in ip-allow-rules.json: 3

Checking new or updated rules to add
  Adding rule: proxy-eu with value: 192.168.88.0/23
  Adding rule: proxy-us with value: 192.168.1.1
  Adding rule: proxy-us with value: 192.168.1.2

Checking rules no longer relevant for deletion
  Deleting rule:  with value: 1.2.3.4 with id: IALE_kwHOBbB18s5ADoiX
  Deleting rule: test with value: 1.2.3.5 with id: IALE_kwHOBbB08s4ADkiT

Done
```