### PR TITLE
Update package migration scripts

### DIFF
--- a/gh-cli/delete-packages-in-organization.sh
+++ b/gh-cli/delete-packages-in-organization.sh
@@ -12,6 +12,11 @@
 # - rubygems
 #
 
+# need scopes: read:packages, delete:packages
+# gh auth refresh -h github.com -s read:packages,delete:packages
+
+set -e
+
 if [ $# -ne "2" ]; then
     echo "Usage: $0 <org> <package_type>"
     exit 1
@@ -20,11 +25,11 @@ fi
 org=$1
 package_type=$2
 
+packages=$(gh api /orgs/$org/packages?package_type=$package_type -q '.[].name')
+
 echo "⛔️ WARNING: This is going to delete all $package_type packages in the $org organization in 10 seconds"
 echo ". . ... ..."
 sleep 10
-
-packages=$(gh api /orgs/$org/packages?package_type=$package_type -q '.[].name')
 
 for package in $packages
 do

--- a/scripts/migrate-nuget-packages-between-github-instances.sh
+++ b/scripts/migrate-nuget-packages-between-github-instances.sh
@@ -12,7 +12,8 @@
 #
 # Notes:
 # - This script installs [gpr](https://github.com/jcansdale/gpr) locally to the `./temp/tools` directory
-# - This script assumes that the target org's repo name is the same as the source (the target repo doesn't _need_ to exist, the package just won't be mapped to a repo)
+# - This script assumes that the target org's repo name is the same as the source
+# - If the repo doesn't exist, the package will still import but won't be mapped to a repo
 #
 
 if [ $# -ne "3" ]; then


### PR DESCRIPTION
- maven package migration script: 
  - change logic `mvnfeed-cli` is installed
  - use `GH_TOKEN=$GH_SOURCE_PAT` for only authenticating a single `gh api` call
  - removing unneeded api call to retrieve current user for source/target
  - updating notes
- npm package migration script: 
  - use `GH_TOKEN=$GH_SOURCE_PAT` for only authenticating a single `gh api` call
  - updating notes
- nuget package migration script:
  - updating notes
- delete packages script: 
  - retrieving packages before sleep in order to error out sooner