### PR TITLE
copy permissions between org repos now also creates the child teams

### DIFF
--- a/gh-cli/README.md
+++ b/gh-cli/README.md
@@ -197,10 +197,10 @@ Copy user and team repository member permissions to another repository (it can b
 
 External collaborators are not copied intentionally.
 
-If the team on the target organization doesn't exist, one will be created (same name, description, privacy, and notification settings ONLY).
+If the team (or children of that team) on the target organization doesn't exist, one will be created (same name, description, privacy, and notification settings ONLY),if the team has children teams those will also be created (full tree, not only direct children).
 
 > **Note** 
-> The created team will not be a full copy, **Only** name and description are honored. If the team is part of a child/parent relationship, or it's associated with an IDP group it will not be honored. If you want to change this behavior, you can modify the `createTeamIfNotExists` function.
+> The created team will not be a full copy, **Only** name, description and visibilility are honored. If the team is is associated with an IDP group it will not be honored. If you want to change this behavior, you can modify the `__copy_team_and_children_if_not_exists_at_target.sh` script.
 
 This script requires 2 environment variables (with another optional one):
 
@@ -832,12 +832,18 @@ Example output:
 
 Sets the parents of teams in an target organization based on existing child/parent relantion ship on a source organization teams.
 
-This is uself to mirror a parent child/relantionship between teams on two organizations.
+This is useful to mirror a parent child/relationship between teams on two organizations.
 
 This script requires 2 environment variables;
 
 - SOURCE_TOKEN - A GitHub Token to access data from the source organization. Requires `org:read` scopes.
 - TARGET_TOKEN - A GitHub Token to set data on the target organization. Requires `org:admin` and `repo` scopes.
+
+The script has three parameters:
+
+- `source-org` - The source organization name from which team hiercarchy will be read
+- `target-org` - The target organization name to which teams will be updated OR created
+- `create parent(s) if not exist` - OPTIONAL (default `false`) if set to true at the teams have parents that do not exist in the target org, they will be created. (also creates parents of parents) otherwise it will print a message parent doesn't exist and it will skipped.
 
 ### remove-branch-protection-status-checks.sh
 

--- a/gh-cli/README.md
+++ b/gh-cli/README.md
@@ -200,7 +200,7 @@ External collaborators are not copied intentionally.
 If the team (or children of that team) on the target organization doesn't exist, one will be created (same name, description, privacy, and notification settings ONLY),if the team has children teams those will also be created (full tree, not only direct children).
 
 > **Note** 
-> The created team will not be a full copy, **Only** name, description and visibilility are honored. If the team is is associated with an IDP group it will not be honored. If you want to change this behavior, you can modify the `__copy_team_and_children_if_not_exists_at_target.sh` script.
+> The created team will not be a full copy, **Only** name, description and visibilility are honored. If the team is is associated with an IDP group it will not be honored. If you want to change this behavior, you can modify the `internal/__copy_team_and_children_if_not_exists_at_target.sh` script.
 
 This script requires 2 environment variables (with another optional one):
 

--- a/gh-cli/__copy_team_and_children_if_not_exists_at_target.sh
+++ b/gh-cli/__copy_team_and_children_if_not_exists_at_target.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# NOTE: this script is called from parent-organization-teams.sh it's not meant to be called directly
+# NOTE: this script is called from copy-permissions-between-org-repos.sh it's not meant to be called directly
 
 if [ $# -lt 3 ]; then
     echo "usage: $0 <source org> <target org> <slug> <parent slug> <parent id> [logfilename]"

--- a/gh-cli/__copy_team_and_children_if_not_exists_at_target.sh
+++ b/gh-cli/__copy_team_and_children_if_not_exists_at_target.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+
+# NOTE: this script is called from parent-organization-teams.sh it's not meant to be called directly
+
+if [ $# -lt 3 ]; then
+    echo "usage: $0 <source org> <target org> <slug> <parent slug> <parent id> [logfilename]"
+    echo "WARNING: this is an internal function. Do not call directly"
+    exit 1
+fi
+
+if [ -z "$SOURCE_TOKEN" ]; then
+    echo "SOURCE_TOKEN must be set"
+    exit 1
+fi
+
+if [ -z "$TARGET_TOKEN" ]; then
+    echo "TARGET_TOKEN must be set"
+    exit 1
+fi
+
+source_org=$1
+target_org=$2
+slug=$3
+parent_slug=$4
+parent_id=$5
+
+script_path=$(dirname "$0")
+
+RED='\033[0;31m'
+function debug() {
+    if [ "$DEBUG" = "true" ]; then
+        echo -e "${RED}DBG: $@" >&2
+        # reset color
+        echo -e "\033[0m" >&2
+    fi
+}
+
+debug "__copy_team_if_not_exists_at_target.sh $source_org $target_org $slug parent=$parent_slug $parent_id"
+
+# Get team details from source
+SOURCE_TEAM_JSON=$(GH_TOKEN=$SOURCE_TOKEN gh api "orgs/$source_org/teams/$slug" --jq '{name, description, privacy, notification_setting, parent_id:. .parent.id  ,parent_slug: .parent.slug}')
+
+# https://docs.github.com/en/rest/teams/teams?apiVersion=2022-11-28#get-a-team-by-name
+if ! TARGET_TEAM_JSON=$(GH_TOKEN=$TARGET_TOKEN gh api "orgs/$target_org/teams/$slug" --jq '{name, description, privacy,notification_setting, id: .id, parent_id:. .parent.id, parent_slug: .parent.slug}' 2>/dev/null); then
+    echo "  $slug does not exist at target. Creating it"
+
+    SOURCE_TEAM_JSON=$(echo "$SOURCE_TEAM_JSON" | jq 'del(.id) | del(.parent_id) | del(.parent_slug)')
+
+    if [ -n "$parent_id" ]; then
+        SOURCE_TEAM_JSON=$(echo "$SOURCE_TEAM_JSON" | jq --argjson parent_id "$parent_id" '.parent_team_id = $parent_id')
+    fi
+
+    parent_desc=""
+    if [ -n "$parent_slug" ]; then
+        parent_desc=" with parent $parent_slug ($parent_id)"
+    fi
+
+    debug "CREATING $slug with $SOURCE_TEAM_JSON"
+
+    # https://docs.github.com/en/rest/teams/teams?apiVersion=2022-11-28#create-a-team
+    new_team_id=$(GH_TOKEN=$TARGET_TOKEN gh api --method POST "orgs/$target_org/teams" --input - --jq .id <<<"$SOURCE_TEAM_JSON")
+
+    echo "  Created team $slug ($new_team_id) $parent_desc"
+
+    # Remove us from the team, so the team is empty
+    if [ -z "$__ghuser" ]; then
+        __ghuser=$(GH_TOKEN=$TARGET_TOKEN gh api user --jq '.login')
+    fi
+    GH_TOKEN=$TARGET_TOKEN gh api --method DELETE "orgs/$target_org/teams/$slug/memberships/$__ghuser" --silent
+else
+
+    target_parent_id=$(echo "$TARGET_TEAM_JSON" | jq -r '.parent_id')
+    target_parent_slug=$(echo "$TARGET_TEAM_JSON" | jq -r '.parent_slug')
+
+    debug "Found existing team $slug at target with $TARGET_TEAM_JSON"
+
+    parent_desc=""
+    if [ "$target_parent_slug" != "null" ]; then
+        parent_desc="with parent [$target_parent_slug]"
+    fi
+    echo "  Team $slug already exists at target $parent_desc"
+
+    # Set parentid?
+    if [ -n "$parent_id" ]; then
+    
+        if [ "$target_parent_id" != "$parent_id" ]; then
+            if [ "$target_parent_id" != "null" ]; then
+                echo "  WARNING: Team [$slug] already has a parent [$target_parent_slug] with id [$target_parent_id]. State is ambiguous. Skipping it (If this is not intentional you will need to fix it manually)."
+            else
+                echo "  Set parent [$parent_slug] to [$slug]"
+                GH_TOKEN=$TARGET_TOKEN gh api -X PATCH "orgs/$target_org/teams/$slug" \
+                    -F parent_team_id="$parent_id" \
+                    -f privacy=closed \
+                    --silent
+            fi
+
+        fi
+    fi
+
+    new_team_id=$(echo "$TARGET_TEAM_JSON" | jq -r '.id')
+
+    debug "Using existing team $slug with id $new_team_id"
+fi
+
+# Get child teams and create them/parent them
+GH_TOKEN=$SOURCE_TOKEN gh api "orgs/$source_org/teams/$slug/teams" --jq '.[].slug' | while read -r child_slug; do
+    # Recursive call to create the child team
+    "$0" "$source_org" "$target_org" "$child_slug" "$slug" "$new_team_id"
+done

--- a/gh-cli/copy-permissions-between-org-repos.sh
+++ b/gh-cli/copy-permissions-between-org-repos.sh
@@ -63,7 +63,7 @@ GH_TOKEN=$SOURCE_TOKEN gh api "repos/$source_org/$repo/collaborators?affiliation
 
     echo "Adding user: $login with $role to $target_org/$target_repo"
 
-    GH_TOKEN=$TARGET_TOKEN ./add-collaborator-to-repository.sh "$target_org" "$target_repo" "$login" "$role"
+    GH_TOKEN=$TARGET_TOKEN "$script_path/add-collaborator-to-repository.sh" "$target_org" "$target_repo" "$login" "$role"
 done
 
 echo -e "\nGranting Permissions to teams:\n"
@@ -76,7 +76,7 @@ GH_TOKEN=$SOURCE_TOKEN gh api "repos/$source_org/$repo/teams" --jq '.[] | [.name
     # copy team from source if not exists at target. This will include also children teams
     DEBUG=$DEBUG "$script_path/__copy_team_and_children_if_not_exists_at_target.sh" "$source_org" "$target_org" "$slug"
 
-    GH_TOKEN=$TARGET_TOKEN ./add-team-to-repository.sh "$target_org" "$target_repo" "$slug" "$permission"
+    GH_TOKEN=$TARGET_TOKEN "$script_path/add-team-to-repository.sh" "$target_org" "$target_repo" "$slug" "$permission"
 done
 
 echo -e "\n"

--- a/gh-cli/copy-permissions-between-org-repos.sh
+++ b/gh-cli/copy-permissions-between-org-repos.sh
@@ -74,7 +74,7 @@ GH_TOKEN=$SOURCE_TOKEN gh api "repos/$source_org/$repo/teams" --jq '.[] | [.name
     echo "Adding team: [$name] ($slug) with $permission to $target_org/$target_repo"
 
     # copy team from source if not exists at target. This will include also children teams
-    DEBUG=$DEBUG "$script_path/__copy_team_and_children_if_not_exists_at_target.sh" "$source_org" "$target_org" "$slug"
+    DEBUG=$DEBUG "$script_path/internal/__copy_team_and_children_if_not_exists_at_target.sh" "$source_org" "$target_org" "$slug"
 
     GH_TOKEN=$TARGET_TOKEN "$script_path/add-team-to-repository.sh" "$target_org" "$target_repo" "$slug" "$permission"
 done

--- a/gh-cli/copy-permissions-between-org-repos.sh
+++ b/gh-cli/copy-permissions-between-org-repos.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [ $# -ne 4 ]
+if [ $# -lt 3 ]
   then
     echo "usage: $0 <source org> <repo> <target org> [target repo]"
     echo "If target repo is skipped the name will be same as the source repo"
@@ -24,6 +24,8 @@ repo=$2
 target_org=$3
 target_repo=${4:-$repo}
 
+script_path=$(dirname "$0")
+
 if [ -z "$MAP_USER_SCRIPT" ]; then
     echo "WARNING: MAP_USER_SCRIPT is not set. No mapping will be performed."
     echo "Add a script to the environment variable MAP_USER_SCRIPT to map users from $source_org to $target_org"
@@ -46,25 +48,9 @@ function map_role() {
     fi
 }
 
-function createTeamIfNotExists() {
-    source_org=$1
-    target_org=$2
-    slug=$3
-
-    # https://docs.github.com/en/rest/teams/teams?apiVersion=2022-11-28#get-a-team-by-name
-    GH_TOKEN=$TARGET_TOKEN gh api "orgs/$target_org/teams/$slug" --silent
-    if [ $? != 0  ]; then
-        JSON=$(GH_TOKEN=$SOURCE_TOKEN gh api "orgs/$source_org/teams/$slug" --jq '{name, description, privacy,notification_setting}')
-
-        # https://docs.github.com/en/rest/teams/teams?apiVersion=2022-11-28#create-a-team
-        GH_TOKEN=$TARGET_TOKEN gh api --method POST "orgs/$target_org/teams" --input - <<< "$JSON" --silent
-
-        # Remove us from the team, so the team is empty
-        ghuser=$(GH_TOKEN=$TARGET_TOKEN gh api user --jq '.login')
-        GH_TOKEN=$TARGET_TOKEN gh api --method DELETE  "orgs/$target_org/teams/$slug/memberships/$ghuser" --silent
-
-    fi
-}
+# Cache running user for the helper script
+__ghuser=$(GH_TOKEN=$TARGET_TOKEN gh api user --jq '.login')
+export __ghuser
 
 echo -e "\nGranting Permissions to users:\n"
 
@@ -87,7 +73,8 @@ GH_TOKEN=$SOURCE_TOKEN gh api "repos/$source_org/$repo/teams" --jq '.[] | [.name
     permission=${fields[2]}
     echo "Adding team: [$name] ($slug) with $permission to $target_org/$target_repo"
 
-    createTeamIfNotExists "$source_org" "$target_org" "$slug"
+    # copy team from source if not exists at target. This will include also children teams
+    DEBUG=$DEBUG "$script_path/__copy_team_and_children_if_not_exists_at_target.sh" "$source_org" "$target_org" "$slug"
 
     GH_TOKEN=$TARGET_TOKEN ./add-team-to-repository.sh "$target_org" "$target_repo" "$slug" "$permission"
 done

--- a/gh-cli/internal/__copy_team_and_children_if_not_exists_at_target.sh
+++ b/gh-cli/internal/__copy_team_and_children_if_not_exists_at_target.sh
@@ -35,7 +35,7 @@ function debug() {
     fi
 }
 
-debug "__copy_team_if_not_exists_at_target.sh $source_org $target_org $slug parent=$parent_slug $parent_id"
+debug "internal/__copy_team_if_not_exists_at_target.sh $source_org $target_org $slug parent=$parent_slug $parent_id"
 
 # Get team details from source
 SOURCE_TEAM_JSON=$(GH_TOKEN=$SOURCE_TOKEN gh api "orgs/$source_org/teams/$slug" --jq '{name, description, privacy, notification_setting, parent_id:. .parent.id  ,parent_slug: .parent.slug}')


### PR DESCRIPTION
When a team is copied from source to target, previously it was ensured the team existed at the target by copying it. Now it also ensures all children teams of copied teams are also at the target (creates them if necessary).

