### PR TITLE
Get a list of CODEOWNERS with errors on a given org

### DIFF
--- a/gh-cli/README.md
+++ b/gh-cli/README.md
@@ -558,6 +558,14 @@ Gets the usage of a label in a repository. Returns data in table format.
 
 Gets a list of repositories in an organization that have had code pushed to it in the last X days.
 
+### get-organization-codeowner-errors-tsv.sh
+
+Gets a TSV with a list of [CODEOWNERS](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners) files that have errors in them, this will allow to identify which CODEOWNERS requires fixing.
+
+The list will contain the repository name, source (CODEOWNERS file), and kind of error.
+
+Repositories with no CODEONWERS files or CODEOWNERS errors will not be listed.
+
 ### get-organization-id.sh
 
 Get the organization ID used for other GraphQL calls. Use the login of the Organization as the input.

--- a/gh-cli/get-organization-codeowner-errors-tsv.sh
+++ b/gh-cli/get-organization-codeowner-errors-tsv.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+if [ $# -lt "1" ]; then
+    echo "Usage: $0 <organization>"
+    exit 1
+fi
+
+organization=$1
+
+gh api graphql --paginate -f org="$organization" -f query='query ($org: String! $endCursor: String) {
+	organization(login: $org) {
+		repositories(first: 100, after: $endCursor) {
+			pageInfo { hasNextPage endCursor }
+			nodes {
+				name
+				codeowners {
+					errors {
+						path
+						source
+						kind
+						message
+					}
+				}
+			}
+		}
+	}
+}' | jq -r '.data.organization.repositories.nodes[] | select(.codeowners != null) | select(.codeowners.errors != null) | .name as $name | .codeowners.errors[] | [$name, .path, (.source | gsub("\n"; "")), .kind] | @tsv'


### PR DESCRIPTION
Gets a TSV with the list of errors in codeowners file

repositories with no CODEOWNER files or with no errors will not be show

The list will contain the repository name, source (CODEOWNERS file), and kind of error.