### PR TITLE
set 'registry=<host>' in .npmrc to allow auth

### DIFF
--- a/scripts/migrate-npm-packages-between-github-instances.sh
+++ b/scripts/migrate-npm-packages-between-github-instances.sh
@@ -46,7 +46,7 @@ cd ./temp
 temp_dir=$(pwd)
 
 # set up .npmrc for target org
-echo @$TARGET_ORG:https://npm.pkg.$TARGET_HOST/ > $temp_dir/.npmrc && echo "//npm.pkg.$TARGET_HOST/:_authToken=$GH_TARGET_PAT" >> $temp_dir/.npmrc
+echo @$TARGET_ORG:registry=https://npm.pkg.$TARGET_HOST/ > $temp_dir/.npmrc && echo "//npm.pkg.$TARGET_HOST/:_authToken=$GH_TARGET_PAT" >> $temp_dir/.npmrc
 
 packages=$(GH_HOST="$SOURCE_HOST" GH_TOKEN=$GH_SOURCE_PAT gh api --paginate "/orgs/$SOURCE_ORG/packages?package_type=npm" -q '.[] | .name + " " + .repository.name')
 


### PR DESCRIPTION
Failed for me without registry key.
See format here: https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-npm-registry#publishing-a-package-using-a-local-npmrc-file