### PR TITLE
feat: improve status checks script

### DIFF
--- a/gh-cli/README.md
+++ b/gh-cli/README.md
@@ -1026,9 +1026,12 @@ See the [docs](https://docs.github.com/en/rest/search?apiVersion=2022-11-28#sear
 
 ### set-branch-protection-status-checks.sh
 
-Set the branch protection status check contexts.
+Set the branch protection status checks.
 
-See the [docs](https://docs.github.com/en/rest/branches/branch-protection?apiVersion=2022-11-28#set-status-check-contexts) for more information.
+> [!NOTE]
+> Set the App ID for GitHub Actions (`15368`), GitHub Advanced Security (`57789`), or Azure Pipelines (`9426`) if you are using those as a source for status checks for best security.
+
+See the [docs](https://docs.github.com/en/rest/branches/branch-protection?apiVersion=2022-11-28#update-status-check-protection) for more information.
 
 ### set-ip-allow-list-rules.sh
 

--- a/gh-cli/set-branch-protection-status-checks.sh
+++ b/gh-cli/set-branch-protection-status-checks.sh
@@ -1,11 +1,35 @@
 #!/bin/bash
 
-gh api -X PUT /repos/joshjohanning-org/circleci-test/branches/main/protection/required_status_checks/contexts \
+# Sets the required status checks for a branch
+
+# 15368 is the App ID for GitHub Actions as a check source
+# 57789 is the App ID for GitHub Advanced Security as a check source
+# 9426 is the App ID for Azure Pipelines as a check source
+# `strict: true` means that branch needs to be up to date before merging
+
+gh api -X PATCH /repos/joshjohanning-org/circleci-test/branches/main/protection/required_status_checks \
   --input - << EOF
 {
-  "contexts": [
-    "ci/circleci: say-hello",
-    "ci/circleci: test-go-2"
-  ]
+  "checks": [
+    {
+      "context": "ci/circleci: say-hello"
+    },
+    {
+      "context": "ci/circleci: test-go-2"
+    },
+    {
+      "context": "build",
+      "app_id": 15368
+    },
+    {
+      "context": "CodeQL",
+      "app_id": 57789
+    },
+    {
+      "context": "joshjohanning-org.tailspin-spacegame-web-demo (Build BuildJob)",
+      "app_id": 9426
+    }
+  ],
+  "strict": true
 }
 EOF


### PR DESCRIPTION
- Using the "[Update status check protection](https://docs.github.com/en/rest/branches/branch-protection?apiVersion=2022-11-28#update-status-check-protection)" API instead of the (deprecated?) "[Set status check contexts](https://docs.github.com/en/rest/branches/branch-protection?apiVersion=2022-11-28#set-status-check-contexts)" API
- This allows us to set the App ID - GitHub Actions (`15368`), GitHub Advanced Security (`57789`), or Azure Pipelines (`9426`) - for the  status checks for best security