### PR TITLE
feat!: improving status check scripts

### DIFF
--- a/gh-cli/README.md
+++ b/gh-cli/README.md
@@ -1004,11 +1004,17 @@ The script has three parameters:
 - `target-org` - The target organization name to which teams will be updated OR created
 - `create parent(s) if not exist` - OPTIONAL (default `false`) if set to true, the teams which have parents that do not exist in the target org, they will be created. (also creates parents of parents) otherwise it will print a message parent doesn't exist and it will skipped.
 
+### remove-branch-protection-status-check-contexts.sh
+
+Removes specific branch protection status check(s) from a branch protection rule
+
+See the [docs](https://docs.github.com/en/rest/branches/branch-protection?apiVersion=2022-11-28#remove-status-check-contexts) for more information
+
 ### remove-branch-protection-status-checks.sh
 
-Removes a status check from the branch protection status check contexts.
+Unsets the required status checks setting on a branch protection policy (and removes all checks with it)
 
-See the [docs](https://docs.github.com/en/rest/branches/branch-protection?apiVersion=2022-11-28#remove-status-check-contexts) for more information.
+See the [docs](https://docs.github.com/en/rest/branches/branch-protection?apiVersion=2022-11-28#remove-status-check-protection) for more information
 
 ### remove-enterprise-user.sh
 
@@ -1042,10 +1048,10 @@ See the [docs](https://docs.github.com/en/rest/search?apiVersion=2022-11-28#sear
 
 ### set-branch-protection-status-checks.sh
 
-Set the branch protection status checks.
+Set the branch protection status checks - and optionally create a branch protection rule if it doesn't exist or set the required status checks setting on an existing branch protection rule if it isn't set
 
 > [!NOTE]
-> Set the App ID for GitHub Actions (`15368`), GitHub Advanced Security (`57789`), or Azure Pipelines (`9426`) if you are using those as a source for status checks for best security.
+> Set the App ID for GitHub Actions (`15368`), GitHub Advanced Security (`57789`), Azure Pipelines (`9426`), or CircleCI (`302869`) if you are using those as a source for status checks as a best practice (so the check can't be spoofed by another source/app).
 
 See the [docs](https://docs.github.com/en/rest/branches/branch-protection?apiVersion=2022-11-28#update-status-check-protection) for more information.
 

--- a/gh-cli/remove-branch-protection-status-check-contexts.sh
+++ b/gh-cli/remove-branch-protection-status-check-contexts.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# this removes specific branch protection status check(s) from a branch protection rule
+
+gh api -X DELETE /repos/joshjohanning-org/circleci-test/branches/main/protection/required_status_checks/contexts \
+  --input - << EOF
+{
+  "contexts": [
+    "ci/circleci: say-hello",
+    "ci/circleci: test-go-1"
+  ]
+}
+EOF

--- a/gh-cli/remove-branch-protection-status-checks.sh
+++ b/gh-cli/remove-branch-protection-status-checks.sh
@@ -1,11 +1,5 @@
 #!/bin/bash
 
-gh api -X DELETE /repos/joshjohanning-org/circleci-test/branches/main/protection/required_status_checks/contexts \
-  --input - << EOF
-{
-  "contexts": [
-    "ci/circleci: say-hello",
-    "ci/circleci: test-go-1"
-  ]
-}
-EOF
+# this removes ALL branch protection status checks from a branch protection rule
+
+gh api -X DELETE /repos/joshjohanning-org/circleci-test/branches/main/protection/required_status_checks \

--- a/gh-cli/set-branch-protection-status-checks.sh
+++ b/gh-cli/set-branch-protection-status-checks.sh
@@ -2,20 +2,93 @@
 
 # Sets the required status checks for a branch
 
+# Find and specify the APP ID for the check source as a best practice (so the check can't be spoofed by another source/app)
 # 15368 is the App ID for GitHub Actions as a check source
 # 57789 is the App ID for GitHub Advanced Security as a check source
 # 9426 is the App ID for Azure Pipelines as a check source
-# `strict: true` means that branch needs to be up to date before merging
+# 302869 is the App ID for CircleCI as a check source
 
-gh api -X PATCH /repos/joshjohanning-org/circleci-test/branches/main/protection/required_status_checks \
+set -e
+
+org="joshjohanning-org"
+repo="circleci-test"
+branch="main" # wildcards are supported in GraphQL but not the API we're calling to set the status checks
+strict=true # if true, branch needs to be up to date before merging
+ # `skip_branch_protection_rule_exists_check` checks to see if:
+  # 1) there is a branch protection rule that exists and 
+  # 2) that the rule has required status checks enabled 
+  # it will create the rule if it doesn't exist or enable the required status checks if they are not enabled
+skip_branch_protection_rule_exists_check=false
+
+# if skip_branch_protection_rule_exists_check = true
+if [ "$skip_branch_protection_rule_exists_check" == "false" ]; then
+
+  # see if branch protection status checks are enabled
+  echo "Checking if branch protection status checks are enabled for $branch"
+
+branch_protection_rule=$(gh api graphql -H X-Github-Next-Global-ID:1 -f owner="$org" -f repository="$repo" -f query='
+    query ($owner: String!, $repository: String!) {
+      repository(owner: $owner, name: $repository) {
+        branchProtectionRules(first: 100) {
+          nodes {
+            id
+            pattern
+            requiresStatusChecks
+          }
+        }
+        id
+      }
+    }' --jq "{repositoryId: .data.repository.id, branchProtectionRules: (.data.repository.branchProtectionRules.nodes | map(select(.pattern == \"$branch\") | {id: .id, pattern: .pattern, requiresStatusChecks: .requiresStatusChecks}))}")
+
+  requires_status_checks=$(echo $branch_protection_rule | jq -r '.branchProtectionRules[0].requiresStatusChecks')
+  branch_protection_rule_id=$(echo $branch_protection_rule | jq -r '.branchProtectionRules[0].id')
+  branch_protection_pattern=$(echo $branch_protection_rule | jq -r '.branchProtectionRules[0].pattern')
+  repo_id=$(echo $branch_protection_rule | jq -r '.repositoryId')
+
+  if [ "$branch_protection_rule_id" == "null" ]; then
+    echo " ... No branch protection rule exists for $branch, we need to create one quick 🕔"
+    gh api graphql -H X-Github-Next-Global-ID:1 -f repositoryId="$repo_id" -f pattern="$branch" -f query='
+      mutation ($repositoryId: ID!, $pattern: String!) {
+        createBranchProtectionRule(input: {repositoryId: $repositoryId, pattern: $pattern, requiresStatusChecks: true}) {
+          branchProtectionRule {
+            id
+            pattern
+            requiresStatusChecks
+          }
+        }
+      }' --jq '.data.createBranchProtectionRule.branchProtectionRule'
+    echo " ... okay now that's done, let's set the required status checks"
+  fi
+
+  if [ "$requires_status_checks" == "false" ]; then
+    echo " ... Branch protection status checks are not enabled for $branch, we need to set that quick 🕖"
+    gh api graphql -f id="$branch_protection_rule_id" -f query='
+      mutation ($id: ID!) { 
+        updateBranchProtectionRule(input: {branchProtectionRuleId: $id, requiresStatusChecks: true} ) {
+          branchProtectionRule {
+            id
+            pattern
+            requiresStatusChecks
+          }
+        } 
+      }' --jq '.data.updateBranchProtectionRule.branchProtectionRule'
+    echo " ... okay now that's done, let's set the required status checks"
+    else
+      echo " ... Branch protection status checks are already enabled ✅"
+  fi
+fi
+
+gh api -X PATCH /repos/$org/$repo/branches/$branch/protection/required_status_checks \
   --input - << EOF
 {
   "checks": [
     {
-      "context": "ci/circleci: say-hello"
+      "context": "ci/circleci: say-hello",
+      "app_id": 302869
     },
     {
-      "context": "ci/circleci: test-go-2"
+      "context": "ci/circleci: test-go-2",
+      "app_id": 302869
     },
     {
       "context": "build",
@@ -33,3 +106,5 @@ gh api -X PATCH /repos/joshjohanning-org/circleci-test/branches/main/protection/
   "strict": true
 }
 EOF
+
+echo "required status checks set ✅"


### PR DESCRIPTION
- breaking change: adding/renaming `remove-branch-protection-status-checks.sh` to `remove-branch-protection-status-check-contexts.sh`
- breaking change: using `remove-branch-protection-status-checks.sh` to remove ALL branch protection status checks (unsets the setting)
- improving `set-branch-protection-status-checks.sh` to also create a branch protection rule if it doesn't exist, and if a rule already does exist, ensure that the required status checks setting is set