### PR TITLE
fix: mavenfeed-cli pkg was broken

### DIFF
--- a/scripts/migrate-maven-packages-between-github-instances.sh
+++ b/scripts/migrate-maven-packages-between-github-instances.sh
@@ -52,7 +52,7 @@ mkdir -p ./artifacts
 # check if python3 is installed
 if command -v python3 &> /dev/null; then
   if [ ! -d "./tool/mvnfeed-cli" ]; then
-    git clone https://github.com/microsoft/mvnfeed-cli.git ./tool/mvnfeed-cli
+    git clone https://github.com/kenmuse/mvnfeed-cli.git ./tool/mvnfeed-cli
     cd ./tool/mvnfeed-cli && python3 ./scripts/dev_setup.py && cd $temp_dir
   fi
 else


### PR DESCRIPTION
> the mvnfeed-cli codebase for transferring maven packages has gotten a bit out of date. Turns out it fails for GitHub to GitHub. Based on an open issue, I have a patch that MIGHT work https://github.com/microsoft/mvnfeed-cli/compare/master...kenmuse:mvnfeed-cli:kenmuse/gh?expand=1


>  it downloads the files (and they seem to be valid), but when uploading it appears to put a content-disposition MIME separator into the payload. That wrecks the `pom.xml` and the `JAR` file. It's a sloppy fix, but seemed to resolve the issue. Not sure if it breaks everything else. Took a bit to set it up since some of the code it references was deprecated (so it pulls newer dependencies that are not compatible as-is)

Thanks @kenmuse for the fix! 
