### PR TITLE
feat: enhance sso creds scripts and use json outputs by default

### DIFF
--- a/gh-cli/get-sso-credential-authorizations.sh
+++ b/gh-cli/get-sso-credential-authorizations.sh
@@ -3,7 +3,11 @@
 # more info: 
 # - https://github.blog/changelog/2019-04-09-credential-authorizations-api/
 # - https://github.blog/changelog/2021-11-09-expiration-dates-of-saml-authorized-pats-available-via-api/
+# - https://docs.github.com/en/enterprise-cloud@latest/rest/orgs/orgs?apiVersion=2022-11-28#list-saml-sso-authorizations-for-an-organization
 
-# gets both "personal access token" and "SSH key" credential types and their expiration (if applicable)
+# gets all credential types ("personal access token", "SSH key", "OAuth app token", and "GitHub app token") and their expiration (if applicable)
 
-gh api --paginate /orgs/githubcustomers/credential-authorizations --jq='.[] | "login: \(.login)    expiration: \(.authorized_credential_expires_at)    ID: \(.credential_id)    note: \(.authorized_credential_note) type: \(.credential_type)"'
+gh api --paginate /orgs/githubcustomers/credential-authorizations
+
+# old - raw text output, 1 per line
+# gh api --paginate /orgs/githubcustomers/credential-authorizations --jq='.[] | "login: \(.login)    expiration: \(.authorized_credential_expires_at)    ID: \(.credential_id)    note: \(.authorized_credential_note) type: \(.credential_type)"'

--- a/gh-cli/get-sso-enabled-pats.sh
+++ b/gh-cli/get-sso-enabled-pats.sh
@@ -3,6 +3,13 @@
 # more info: 
 # - https://github.blog/changelog/2019-04-09-credential-authorizations-api/
 # - https://github.blog/changelog/2021-11-09-expiration-dates-of-saml-authorized-pats-available-via-api/
+# - https://docs.github.com/en/enterprise-cloud@latest/rest/orgs/orgs?apiVersion=2022-11-28#list-saml-sso-authorizations-for-an-organization
 
-# credential_type: personal access token, SSH key
-gh api --paginate /orgs/githubcustomers/credential-authorizations --jq='.[] | select(.credential_type == "personal access token") | "login: \(.login)  expiration: \(.authorized_credential_expires_at)  ID: \(.credential_id)  note: \(.authorized_credential_note)  type: \(.credential_type)"'
+# credential_type: personal access token, SSH key, OAuth app token, GitHub app token
+gh api --paginate /orgs/githubcustomers/credential-authorizations --jq='.[] | select(.credential_type == "personal access token" and .token_last_eight != null)' # the null check is b/c we only want to get active PATs
+
+# old - raw text output, 1 per line
+# gh api --paginate /orgs/githubcustomers/credential-authorizations --jq='.[] | select(.credential_type == "personal access token" and .token_last_eight != null) | "login: \(.login)  expiration: \(.authorized_credential_expires_at)  ID: \(.credential_id)  note: \(.authorized_credential_note)  type: \(.credential_type))"'
+
+# old - raw text output, 1 per line, with scopes
+# gh api --paginate /orgs/githubcustomers/credential-authorizations --jq='.[] | select(.credential_type == "personal access token" and .token_last_eight != null) | "login: \(.login)  expiration: \(.authorized_credential_expires_at)  ID: \(.credential_id)  note: \(.authorized_credential_note)  type: \(.credential_type)  scopes: \((.scopes // ["None"]) | join(", "))"'

--- a/gh-cli/get-sso-enabled-ssh-keys.sh
+++ b/gh-cli/get-sso-enabled-ssh-keys.sh
@@ -3,6 +3,10 @@
 # more info: 
 # - https://github.blog/changelog/2019-04-09-credential-authorizations-api/
 # - https://github.blog/changelog/2021-11-09-expiration-dates-of-saml-authorized-pats-available-via-api/
+# - https://docs.github.com/en/enterprise-cloud@latest/rest/orgs/orgs?apiVersion=2022-11-28#list-saml-sso-authorizations-for-an-organization
 
-# credential_type: personal access token, SSH key
-gh api --paginate /orgs/githubcustomers/credential-authorizations --jq='.[] | select(.credential_type == "SSH key") | "login: \(.login)    ID: \(.credential_id)    title: \(.authorized_credential_title)    type: \(.credential_type)"'
+# credential_type: personal access token, SSH key, OAuth app token, GitHub app token
+gh api --paginate /orgs/githubcustomers/credential-authorizations --jq='.[] | select(.credential_type == "SSH key")'
+
+# old - raw text output, 1 per line
+# gh api --paginate /orgs/githubcustomers/credential-authorizations --jq='.[] | select(.credential_type == "SSH key") | "login: \(.login)    ID: \(.credential_id)    title: \(.authorized_credential_title)    type: \(.credential_type)"'


### PR DESCRIPTION
Updates to API references and credential types:

* [`gh-cli/get-sso-credential-authorizations.sh`](diffhunk://#diff-04b58c65b600bfe497e78fafcf328022703c6b672adfaa2e037c4025423f2f32R6-R13): Added a new API reference and expanded the list of credential types to include "OAuth app token" and "GitHub app token". Also, the `gh api` command was modified to improve the output format.
* [`gh-cli/get-sso-enabled-pats.sh`](diffhunk://#diff-1ffb237438fa1ed82f313abb13d3c120ba224fe5832d1b7a0793646f757e31c2R6-R15): Added a new API reference and expanded the list of credential types to include "OAuth app token" and "GitHub app token". The `gh api` command was also modified to improve the output format and to only get active PATs.
* [`gh-cli/get-sso-enabled-ssh-keys.sh`](diffhunk://#diff-24e53baa00e59bc474a9bd638624f1fc6de258419abec677a07cb8e26bd65e19R6-R12): Added a new API reference and expanded the list of credential types to include "OAuth app token" and "GitHub app token". The `gh api` command was also modified to improve the output format.