### PR TITLE
feat: add scripts for retrieving organization webhooks

### DIFF
--- a/gh-cli/README.md
+++ b/gh-cli/README.md
@@ -789,6 +789,13 @@ Gets the members of a team
 
 Gets a team
 
+### get-organization-webhooks.sh
+
+Gets a list of webhooks in an organization
+
+> [!NOTE]
+> Requires a GitHub PAT instead of using the OAuth token with the `gh api` command - the OAuth token can only retrieve webhooks it created
+
 ### get-organizations-for-user.sh
 
 Gets the list of organizations a user is a member of. This only returns organizations accessible to the person running the script, i.e.: organizations they are also a member of, or public organizations
@@ -796,6 +803,13 @@ Gets the list of organizations a user is a member of. This only returns organiza
 ### get-organizations-projects-count.sh
 
 Gets the count of projects (ProjectsV2) in all organizations in a given enterprise
+
+### get-organizations-webhooks-in-enterprise.sh
+
+Gets a list of webhooks in all organizations in an enterprise
+
+> [!NOTE]
+> Requires a GitHub PAT instead of using the OAuth token with the `gh api` - the OAuth token can only retrieve webhooks it created
 
 ### get-outside-collaborators-added-to-repository.sh
 

--- a/gh-cli/get-organization-webhooks.sh
+++ b/gh-cli/get-organization-webhooks.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+if [ $# -lt 1 ]
+  then
+    echo "usage: $0 <org> <format: tsv|json>" > output.csv/json
+    exit 1
+fi
+
+# need: `gh auth login -h github.com` and auth with a PAT!
+# sine the Oauth token can only receive results for hooks it created for this API call
+
+auth_status=$(gh auth token 2>&1)
+
+if [[ $auth_status == gho_* ]]
+then
+  echo "Token starts with gho_ - use "gh auth login" and authenticate with a PAT with read:org and admin:org_hook scope"
+  exit 1
+fi
+
+export PAGER=""
+org=$1
+format=$2
+if [ -z "$format" ]
+then
+  format="tsv"
+fi
+
+if [ "$format" == "tsv" ]; then
+  echo -e "Organization\tActive\tURL\tCreated At\tUpdated At\tEvents"
+fi
+
+if [ "$format" == "tsv" ]; then
+  gh api "orgs/$org/hooks" --paginate | jq -r --arg org "$org" '.[] | [$org,.active,.config.url, .created_at, .updated_at, (.events | join(","))] | @tsv'
+else
+  gh api "orgs/$org/hooks" --paginate | jq -r --arg org "$org" '.[] | {organization: $org, active: .active, url: .config.url, created_at: .created_at, updated_at: .updated_at, events: .events}'
+fi

--- a/gh-cli/get-organizations-webhooks-in-enterprise.sh
+++ b/gh-cli/get-organizations-webhooks-in-enterprise.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+if [ $# -lt 1 ]
+  then
+    echo "usage: $0 <enterprise-slug> <format: tsv|json>" > output.csv/json
+    exit 1
+fi
+
+# need: `gh auth login -h github.com` and auth with a PAT!
+# sine the Oauth token can only receive results for hooks it created for this API call
+
+auth_status=$(gh auth token 2>&1)
+
+if [[ $auth_status == gho_* ]]
+then
+  echo "Token starts with gho_ - use "gh auth login" and authenticate with a PAT with read:enterprise, reaad:org, and admin:org_hook scope"
+  exit 1
+fi
+
+export PAGER=""
+enterpriseslug=$1
+format=$2
+if [ -z "$format" ]
+then
+  format="tsv"fi
+fi
+
+organizations=$(gh api graphql --paginate -f enterpriseName="$enterpriseslug" -f query='
+query getEnterpriseOrganizations($enterpriseName: String! $endCursor: String) {
+  enterprise(slug: $enterpriseName) {
+    organizations(first: 100, after: $endCursor) {
+      nodes {
+        id
+        login
+      }
+      pageInfo {
+        endCursor
+        hasNextPage
+      }
+    }
+  }
+}' --jq '.data.enterprise.organizations.nodes[].login')
+
+if [ "$format" == "tsv" ]; then
+  echo -e "Organization\tActive\tURL\tCreated At\tUpdated At\tEvents"
+fi
+
+for org in $organizations
+do
+  if [ "$format" == "tsv" ]; then
+    gh api "orgs/$org/hooks" --paginate | jq -r --arg org "$org" '.[] | [$org,.active,.config.url, .created_at, .updated_at, (.events | join(","))] | @tsv'
+  else
+    gh api "orgs/$org/hooks" --paginate | jq -r --arg org "$org" '.[] | {organization: $org, active: .active, url: .config.url, created_at: .created_at, updated_at: .updated_at, events: .events}'
+  fi
+done


### PR DESCRIPTION
Here are the key changes:

* [`gh-cli/get-organization-webhooks.sh`](diffhunk://#diff-b4708d4c6dd746290641f8787172436cbb7d764574743569c5cc2c2e0e5c73f6R1-R36): This script retrieves webhook information for a specified GitHub organization. It checks for proper usage and valid authentication, makes an API call to GitHub to fetch the webhook data, and formats the data as a TSV or JSON object based on user input.

* [`gh-cli/get-organizations-webhooks-in-enterprise.sh`](diffhunk://#diff-dc033a540ce285cedb42e3b00a7f4c07f3202f03e99ba9fc2bf519986432960dR1-R54): This script retrieves webhook information for all organizations within a specified GitHub enterprise. It checks for proper usage and valid authentication, makes API calls to GitHub to fetch the webhook data for each organization, and formats the data as a TSV or JSON object based on user input.

These scripts will help in automating the process of retrieving webhook information for GitHub organizations and enterprises, thus improving efficiency.