### PR TITLE
Add organizations custom repository roles count script

### DIFF
--- a/gh-cli/README.md
+++ b/gh-cli/README.md
@@ -808,6 +808,10 @@ Gets a list of apps (and app information) in all organizations in a given enterp
 
 Gets the usage of CODEOWNERS files in all repositories in all organizations in a given enterprise (checks `HEAD` for `./`, `./.github`, and `./docs` and returns `TRUE` or `FALSE` for each repository)
 
+### get-organizations-custom-repository-roles-count.sh
+
+Gets the count of custom repository roles in all organizations in a given enterprise
+
 ### get-organizations-discussions-count.sh
 
 Gets the usage of discussions in all repositories in all organizations in a given enterprise (org-wide discussions have to be created in a repository, so this covers that as well)

--- a/gh-cli/get-organization-webhooks.sh
+++ b/gh-cli/get-organization-webhooks.sh
@@ -5,6 +5,9 @@
 # need: `gh auth login -h github.com` and auth with a PAT!
 # since the Oauth token can only receive results for hooks it created for this API call
 
+# note: tsv is the default format
+# tsv is a subset of fields, json is all fields
+
 if [ $# -lt 1 ]
   then
     echo "usage: $0 <org> <hostname> <format: tsv|json> > output.tsv/json"

--- a/gh-cli/get-organizations-apps-count.sh
+++ b/gh-cli/get-organizations-apps-count.sh
@@ -4,8 +4,7 @@
 
 # need: `gh auth refresh -h github.com -s read:org -s read:enterprise`
 
-# note: tsv is the default format
-# tsv is a subset of fields, json is all fields
+# note: format is tsv
 
 if [ $# -lt 1 ]
   then

--- a/gh-cli/get-organizations-codeowner-usage.sh
+++ b/gh-cli/get-organizations-codeowner-usage.sh
@@ -4,6 +4,8 @@
 
 # need: `gh auth refresh -h github.com -s read:org -s read:enterprise`
 
+# note: format is tsv
+
 if [ $# -lt 1 ]; then
     echo "usage: $0 <enterprise slug> <hostname> > output.tsv"
     exit 1

--- a/gh-cli/get-organizations-custom-repository-roles-count.sh
+++ b/gh-cli/get-organizations-custom-repository-roles-count.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# gets the custom repository roles for all organizations in an enterprise
+
+# need: `gh auth refresh -h github.com -s read:org -s read:enterprise`
+
+# note: format is tsv
+
+if [ $# -lt 1 ]
+  then
+    echo "usage: $0 <enterprise-slug> <hostname> > output.tsv"
+    exit 1
+fi
+
+export PAGER=""
+enterpriseslug=$1
+hostname=$2
+
+# set hostname to github.com by default
+if [ -z "$hostname" ]
+then
+  hostname="github.com"
+fi
+
+organizations=$(gh api graphql --paginate --hostname $hostname -f enterpriseName="$enterpriseslug" -f query='
+query getEnterpriseOrganizations($enterpriseName: String! $endCursor: String) {
+  enterprise(slug: $enterpriseName) {
+    organizations(first: 100, after: $endCursor) {
+      nodes {
+        id
+        login
+      }
+      pageInfo {
+        endCursor
+        hasNextPage
+      }
+    }
+  }
+}' --jq '.data.enterprise.organizations.nodes[].login')
+
+echo -e "Org\tCustoim Role Count"
+
+for org in $organizations
+do
+  gh api "orgs/$org/custom-repository-roles" --hostname $hostname --jq ". | [\"$org\", .total_count] | @tsv"
+done

--- a/gh-cli/get-organizations-discussions-count.sh
+++ b/gh-cli/get-organizations-discussions-count.sh
@@ -4,6 +4,8 @@
 
 # need: `gh auth refresh -h github.com -s read:org -s read:enterprise`
 
+# note: format is tsv
+
 if [ $# -lt 1 ]; then
     echo "usage: $0 <enterprise slug> <hostname> > output.tsv"
     exit 1

--- a/gh-cli/get-organizations-projects-count-classic.sh
+++ b/gh-cli/get-organizations-projects-count-classic.sh
@@ -4,6 +4,8 @@
 
 # need: `gh auth refresh -h github.com -s read:org -s read:enterprise`
 
+# note: format is tsv
+
 if [ $# -lt 1 ]; then
     echo "usage: $0 <enterprise slug> <hostname> > output.tsv"
     exit 1

--- a/gh-cli/get-organizations-projects-count.sh
+++ b/gh-cli/get-organizations-projects-count.sh
@@ -4,6 +4,8 @@
 
 # need: `gh auth refresh -h github.com -s read:org -s read:enterprise`
 
+# note: format is tsv
+
 if [ $# -lt 1 ]; then
     echo "usage: $0 <enterprise slug> <hostname> > output.tsv"
     exit 1

--- a/gh-cli/get-organizations-webhooks.sh
+++ b/gh-cli/get-organizations-webhooks.sh
@@ -5,6 +5,9 @@
 # need: `gh auth login -h github.com` and auth with a PAT!
 # since the Oauth token can only receive results for hooks it created for this API call
 
+# note: tsv is the default format
+# tsv is a subset of fields, json is all fields
+
 if [ $# -lt 1 ]
   then
     echo "usage: $0 <enterprise slug> <hostname> <format: tsv|json> > output.tsv/json"


### PR DESCRIPTION
Addition of new script:

* [`gh-cli/get-organizations-custom-repository-roles-count.sh`](diffhunk://#diff-429ccba8187ba4dcaf78835e6bfaeceaa5cb59351478ddb2fb856dcebd01b433R1-R46): A new script was added that gets the count of custom repository roles in all organizations in a given enterprise. The script includes necessary authentication and usage instructions.

Modifications to output format notes:

* [`gh-cli/get-organization-webhooks.sh`](diffhunk://#diff-b4708d4c6dd746290641f8787172436cbb7d764574743569c5cc2c2e0e5c73f6R8-R10): Added notes about the output format, specifying that tsv is the default format and provides a subset of fields, while json provides all fields. [[1]](diffhunk://#diff-b4708d4c6dd746290641f8787172436cbb7d764574743569c5cc2c2e0e5c73f6R8-R10) [[2]](diffhunk://#diff-8180095de1ab584ccdc80e0283829bbcd3826fe2b7290b696b539bfc891109f0R8-R10)
* `gh-cli/get-organizations-apps-count.sh`, `gh-cli/get-organizations-codeowner-usage.sh`, `gh-cli/get-organizations-discussions-count.sh`, `gh-cli/get-organizations-projects-count-classic.sh`, `gh-cli/get-organizations-projects-count.sh`: Updated the note to specify that the output format is tsv. [[1]](diffhunk://#diff-b8ce3c9301023228950121eb0d831cbbd9c16835c8e882fcceff9ecf462fb106L7-R7) [[2]](diffhunk://#diff-5f385c6120d5e542477d324fa3aff10ca3e1692ae5a5e82a34753004b0db7b87R7-R8) [[3]](diffhunk://#diff-8920e275b392fb01c325918b0beec66c6f0d5181a5d3974974436c63af65f3acR7-R8) [[4]](diffhunk://#diff-62115924e3835c2485425e3f408f442177332d554c70d6ed9e86d8f22e44e692R7-R8) [[5]](diffhunk://#diff-24b1f6beed086c7e1a3f4ee9c41e6f4eef2333dc8e9626b8c1ddd0bc86ff2774R7-R8)

Documentation changes:

* [`gh-cli/README.md`](diffhunk://#diff-9ec2a7e2e655724844893270790b168184c962e7b1ac9fe5dd0c32783cff7fd1R811-R814): Added a description for the new `get-organizations-custom-repository-roles-count.sh` script.