### PR TITLE
feat: adding inventory scripts for self-hosted runners

### DIFF
--- a/gh-cli/README.md
+++ b/gh-cli/README.md
@@ -1035,6 +1035,18 @@ Gets the SBOM for a repository.
 
 Uses the search API for code search.
 
+### get-self-hosted-runners-all-in-organization.sh
+
+Gets a list of all self-hosted runners in an organization, including org-level and repo-level runners.
+
+### get-self-hosted-runners-in-all-repositories.sh
+
+Gets a list of all repo-level self-hosted runners in all repos in an organization.
+
+### get-self-hosted-runners-organization-runners.sh
+
+Gets a list of self-hosted runners configured at the organization level for an organization.
+
 ### get-sso-credential-authorizations.sh
 
 Retrieves a list of both "personal access token" and "SSH key" credential types, the users associated with them, and their expiration (if applicable).

--- a/gh-cli/get-self-hosted-runners-all-in-organization.sh
+++ b/gh-cli/get-self-hosted-runners-all-in-organization.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# gets a list of all self-hosted runners in an organization, including org-level and repo-level runners
+
+# gh cli's token needs to be able to read at the organization level - run this first if it can't
+# gh auth refresh -h github.com -s admin:org
+
+# org owner access (or a custom role with ability to manage self-hosted runners at the org level) is required
+
+if [ -z "$1" ]; then
+  echo "Usage: $0 <org>"
+  echo "Example: ./get-self-hosted-runners-all-in-organization.sh joshjohanning-org"
+  exit 1
+fi
+
+org="$1"
+
+printf "type\trepo\tname\tos\tlabels\tstatus\n"
+
+gh api --paginate /orgs/$org/actions/runners --jq '.runners[] | ["org", "n/a", .name, .os, (.labels | map(.name) | join(",")), .status] | @tsv'
+
+repos=$(gh api graphql --paginate -F org="$org" -f query='query($org: String!$endCursor: String){
+organization(login:$org) {
+    repositories(first:100,after: $endCursor) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      nodes {
+        owner {
+          login
+        }
+        name
+      }
+    }
+  }
+}' --template '{{range .data.organization.repositories.nodes}}{{printf "%s/%s\n" .owner.login .name}}{{end}}')
+
+for repo in $repos; do
+  gh api --paginate /repos/$repo/actions/runners --jq ".runners[] | [\"repo\", \"$repo\", .name, .os, (.labels | map(.name) | join(\",\")), .status] | @tsv"
+done

--- a/gh-cli/get-self-hosted-runners-in-all-repositories.sh
+++ b/gh-cli/get-self-hosted-runners-in-all-repositories.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# gets a list of all repo-level self-hosted runners in all repos in an organization
+
+# for org-level self-hosted runners, see: `get-self-hosted-runners-organization-runners.sh`
+# for all self-hosted runners in an org (at org-level and repo-level), see: `get-self-hosted-runners-all-in-organization.sh`
+  
+if [ -z "$1" ]; then
+  echo "Usage: $0 <org>"
+  echo "Example: ./get-self-hosted-runners-in-all-repositories.sh joshjohanning-org"
+  exit 1
+fi
+
+org="$1"
+
+repos=$(gh api graphql --paginate -F org="$org" -f query='query($org: String!$endCursor: String){
+organization(login:$org) {
+    repositories(first:100,after: $endCursor) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      nodes {
+        owner {
+          login
+        }
+        name
+      }
+    }
+  }
+}' --template '{{range .data.organization.repositories.nodes}}{{printf "%s/%s\n" .owner.login .name}}{{end}}')
+
+printf "repo\tname\tos\tlabels\tstatus\n"
+
+for repo in $repos; do
+  gh api --paginate /repos/$repo/actions/runners --jq ".runners[] | [\"$repo\", .name, .os, (.labels | map(.name) | join(\",\")), .status] | @tsv"
+done

--- a/gh-cli/get-self-hosted-runners-organization-runners.sh
+++ b/gh-cli/get-self-hosted-runners-organization-runners.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# gets a list of self-hosted runners configured at the organization level for an organization
+
+# for repo-level self-hosted runners, see: `get-self-hosted-runners-in-all-repositories.sh`
+# for all self-hosted runners in an org (at org-level and repo-level), see: `get-self-hosted-runners-all-in-organization.sh`
+
+# gh cli's token needs to be able to read at the organization level - run this first if it can't
+# gh auth refresh -h github.com -s admin:org
+
+# org owner access (or a custom role with ability to manage self-hosted runners at the org level) is required
+
+if [ -z "$1" ]; then
+  echo "Usage: $0 <org>"
+  echo "Example: ./get-self-hosted-runners-organization-runners.sh joshjohanning-org"
+  exit 1
+fi
+
+org="$1"
+
+printf "name\tos\tlabels\tstatus\n"
+
+gh api --paginate /orgs/$org/actions/runners --jq '.runners[] | [.name, .os, (.labels | map(.name) | join(",")), .status] | @tsv'


### PR DESCRIPTION
### New Scripts for Listing Self-Hosted Runners:

* [`gh-cli/get-self-hosted-runners-all-in-organization.sh`](diffhunk://#diff-80627d6b73e3fcaf677094e458c418b76701045c83da8ecb675b0350054e6932R1-R41): Script to list all self-hosted runners in an organization, including both organization-level and repository-level runners.
* [`gh-cli/get-self-hosted-runners-in-all-repositories.sh`](diffhunk://#diff-d706e528d231c4cab72466ab2e1375e1aaa9ad3314b083dd7d6e8e46bb5097ceR1-R37): Script to list all repository-level self-hosted runners in all repositories within an organization.
* [`gh-cli/get-self-hosted-runners-organization-runners.sh`](diffhunk://#diff-833f8282ce86f0de6125ca734ad3b62027519623d7ef810c522efa5c4c843fc5R1-R23): Script to list self-hosted runners configured at the organization level.

### Documentation Updates:

* [`gh-cli/README.md`](diffhunk://#diff-9ec2a7e2e655724844893270790b168184c962e7b1ac9fe5dd0c32783cff7fd1R1038-R1049): Added sections to document the new scripts for listing self-hosted runners at different levels within an organization.