### PR TITLE
Add script to get issue type of an issue

### DIFF
--- a/gh-cli/README.md
+++ b/gh-cli/README.md
@@ -673,6 +673,10 @@ Gets info about an enterprise using the [EnterpriseOwnerInfo](https://docs.githu
 
 Gets the status of a [GitHub Enterprise Importer (GEI) migration](https://docs.github.com/en/enterprise-cloud@latest/migrations/using-github-enterprise-importer/migrating-organizations-with-github-enterprise-importer/migrating-organizations-from-githubcom-to-github-enterprise-cloud?tool=api#step-3-check-the-status-of-your-migration).
 
+### get-issue-type-of-issue.sh
+
+Gets the issue type of an issue. See: [Community Discussions Post](https://github.com/orgs/community/discussions/139933)
+
 ### get-label-usage-in-repository.sh
 
 Gets the usage of a label in a repository. Returns data in table format.

--- a/gh-cli/add-sub-issue-to-issue.sh
+++ b/gh-cli/add-sub-issue-to-issue.sh
@@ -55,6 +55,7 @@ mutation($parrentIssueId: ID!, $childIssueId: ID!) {
       title
       number
       url
+      id
       issueType {
         name
       }
@@ -63,6 +64,7 @@ mutation($parrentIssueId: ID!, $childIssueId: ID!) {
       title
       number
       url
+      id
       issueType {
         name
       }

--- a/gh-cli/get-issue-type-of-issue.sh
+++ b/gh-cli/get-issue-type-of-issue.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+# Gets the issue type of an issue
+
+if [ -z "$3" ]; then
+  echo "Usage: $0 <org> <repo> <issue-number>"
+  echo "Example: ./get-issue-type-of-issue.sh joshjohanning-org migrating-ado-to-gh-issues-v2 5"
+  exit 1
+fi
+
+org="$1"
+repo="$2"
+issue_number="$3"
+
+# Define color codes
+RED='\033[0;31m'
+YELLOW='\033[0;33m'
+NC='\033[0m' # No Color
+
+# Fetch the issue ID given the issue number
+issue=$(gh api graphql -H GraphQL-Features:issue_types -f owner="$org" -f repository="$repo" -F number="$issue_number" -f query='
+query ($owner: String!, $repository: String!, $number: Int!) {
+  repository(owner: $owner, name: $repository) {
+    issue(number: $number) {
+      title
+      number
+      url
+      id
+      issueType {
+        name
+      }
+    }
+  }
+}')
+
+# Check if the query was successful
+if [ $? -ne 0 ]; then
+  echo -e "${RED}Issue #$issue_number not found in $org/$repo${NC}"
+  exit 1
+fi
+
+# Extract and format the issue details using jq
+formatted_issue=$(echo "$issue" | jq -r '
+  .data.repository.issue | {
+    title: .title,
+    number: .number,
+    url: .url,
+    id: .id,
+    issueType: .issueType.name
+  }')
+
+# Print the formatted issue details
+echo "$formatted_issue" | jq .
+
+# Check if issue type is null and print a warning
+issue_type=$(echo "$formatted_issue" | jq -r '.issueType')
+if [ "$issue_type" = "null" ]; then
+  echo -e "${YELLOW}Warning: No issue type for $org/$repo#$issue_number.${NC}"
+fi

--- a/gh-cli/get-parent-issue-of-issue.sh
+++ b/gh-cli/get-parent-issue-of-issue.sh
@@ -41,6 +41,7 @@ query($issueId: ID!) {
         title
         number
         url
+        id
         issueType {
           name
         }
@@ -61,7 +62,8 @@ formatted_parent_issue=$(echo "$parent_issue" | jq -r '
     title: .title,
     number: .number,
     url: .url,
-    issueType: .issueType
+    id: .id,
+    issueType: .issueType.name
   }')
 
 # Print the formatted parent issue details

--- a/gh-cli/get-parent-issue-of-issue.sh
+++ b/gh-cli/get-parent-issue-of-issue.sh
@@ -14,6 +14,7 @@ issue_number="$3"
 
 # Define color codes
 RED='\033[0;31m'
+YELLOW='\033[0;33m'
 NC='\033[0m' # No Color
 
 # Fetch the issue ID given the issue number
@@ -68,3 +69,9 @@ formatted_parent_issue=$(echo "$parent_issue" | jq -r '
 
 # Print the formatted parent issue details
 echo "$formatted_parent_issue" | jq .
+
+# Check if parent issue is null and print a warning
+number=$(echo "$formatted_parent_issue" | jq -r '.number')
+if [ "$number" = "null" ]; then
+  echo -e "${YELLOW}Warning: No parent issue for $org/$repo#$issue_number.${NC}"
+fi

--- a/gh-cli/get-sub-issues-of-issue.sh
+++ b/gh-cli/get-sub-issues-of-issue.sh
@@ -43,6 +43,7 @@ query($issueId: ID!, $endCursor: String) {
           title
           number
           url
+          id
           issueType {
             name
           }
@@ -66,7 +67,7 @@ fi
 combined_result=$(echo "$sub_issues" | jq -s '
   {
     totalCount: .[0].data.node.subIssues.totalCount,
-    issues: (map(.data.node.subIssues.nodes) | add)
+    issues: (map(.data.node.subIssues.nodes) | add | map(.issueType = .issueType.name))
   }')
 
 # Print the combined result as a colorized JSON object

--- a/gh-cli/get-sub-issues-of-issue.sh
+++ b/gh-cli/get-sub-issues-of-issue.sh
@@ -14,6 +14,7 @@ issue_number="$3"
 
 # Define color codes
 RED='\033[0;31m'
+YELLOW='\033[0;33m'
 NC='\033[0m' # No Color
 
 # Fetch the issue ID given the issue number
@@ -72,3 +73,9 @@ combined_result=$(echo "$sub_issues" | jq -s '
 
 # Print the combined result as a colorized JSON object
 echo "$combined_result" | jq .
+
+# Check if total is 0 and print a warning
+total=$(echo "$combined_result" | jq -r '.totalCount')
+if [ "$total" -eq 0 ]; then
+  echo -e "${YELLOW}Warning: The total number of sub-issues for $org/$repo#$issue_number is 0.${NC}"
+fi

--- a/gh-cli/remove-issue-issue-type.sh
+++ b/gh-cli/remove-issue-issue-type.sh
@@ -52,6 +52,7 @@ mutation($issueId: ID!) {
       title
       number
       url
+      id
       issueType {
         name
       }

--- a/gh-cli/remove-sub-issue-from-issue.sh
+++ b/gh-cli/remove-sub-issue-from-issue.sh
@@ -77,6 +77,7 @@ mutation($parrentIssueId: ID!, $childIssueId: ID!) {
       title
       number
       url
+      id
       issueType {
         name
       }
@@ -85,6 +86,7 @@ mutation($parrentIssueId: ID!, $childIssueId: ID!) {
       title
       number
       url
+      id
       issueType {
         name
       }

--- a/gh-cli/update-issue-issue-type.sh
+++ b/gh-cli/update-issue-issue-type.sh
@@ -60,6 +60,7 @@ mutation($issueId: ID!, $issueTypeId: ID!) {
       title
       number
       url
+      id
       issueType {
         name
       }


### PR DESCRIPTION
### Enhancements to GraphQL Queries:
* Added the `id` field to multiple GraphQL queries to ensure the issue ID is retrieved along with other issue details. [[1]](diffhunk://#diff-db5b46365c6237cf328e8e31991edd341067b7aa3c72e9bc3bdcea410954d3e7R58) [[2]](diffhunk://#diff-db5b46365c6237cf328e8e31991edd341067b7aa3c72e9bc3bdcea410954d3e7R67) [[3]](diffhunk://#diff-63178b14a029894e97ab7f903706b3e541609f791594c736f2358e44f7f267a7R45) [[4]](diffhunk://#diff-63178b14a029894e97ab7f903706b3e541609f791594c736f2358e44f7f267a7L64-R77) [[5]](diffhunk://#diff-dcd85b01f336539366c12a0c3e62321aa1abf7b9aeff372a63f7636ed2dffbf2R47) [[6]](diffhunk://#diff-dcd85b01f336539366c12a0c3e62321aa1abf7b9aeff372a63f7636ed2dffbf2L69-R81) [[7]](diffhunk://#diff-1e5c2d6b48e9daaf666a9204702d36ee2456099ce6f96b4c27c9e520f3451cd1R55) [[8]](diffhunk://#diff-df13df31631a713aa93fe76935a0393ca997cf3a1287860988b23f0791518727R80) [[9]](diffhunk://#diff-df13df31631a713aa93fe76935a0393ca997cf3a1287860988b23f0791518727R89) [[10]](diffhunk://#diff-0eeace169bda23ef7839e0d5e1c34d4443949d9c9efcf2292a01257ba7b3372fR63)

### New Script:
* Introduced `get-issue-type-of-issue.sh` script to fetch and display the issue type of a specific issue.

### Documentation Update:
* Updated `gh-cli/README.md` to include information about the new `get-issue-type-of-issue.sh` script.

### User Feedback Improvements:
* Added warnings in scripts to notify users when no issue type or parent issue is found, or when the total number of sub-issues is zero. [[1]](diffhunk://#diff-63178b14a029894e97ab7f903706b3e541609f791594c736f2358e44f7f267a7R17) [[2]](diffhunk://#diff-63178b14a029894e97ab7f903706b3e541609f791594c736f2358e44f7f267a7L64-R77) [[3]](diffhunk://#diff-dcd85b01f336539366c12a0c3e62321aa1abf7b9aeff372a63f7636ed2dffbf2R17) [[4]](diffhunk://#diff-dcd85b01f336539366c12a0c3e62321aa1abf7b9aeff372a63f7636ed2dffbf2L69-R81)