### PR TITLE
refactor!: rename get-sub-issue-summary-of-issue.sh to get-sub-issues-summary-of-issue.sh

### DIFF
--- a/gh-cli/README.md
+++ b/gh-cli/README.md
@@ -1096,13 +1096,13 @@ Retrieves all SSO enabled PATs users have created for an organization.
 
 Retrieves all SSO-enabled SSH keys users have created for an organization.
 
-### get-sub-issue-summary-of-issue.sh
-
-Gets a summary of the sub-issues (children) of an issue (parent). See: [Community Discussions Post](https://github.com/orgs/community/discussions/139932)
-
 ### get-sub-issues-of-issue.sh
 
 Gets the sub-issues (children) of an issue (parent). See: [Community Discussions Post](https://github.com/orgs/community/discussions/139932)
+
+### get-sub-issues-summary-of-issue.sh
+
+Gets a summary of the sub-issues (children) of an issue (parent). See: [Community Discussions Post](https://github.com/orgs/community/discussions/139932)
 
 ### get-user-id.sh
 

--- a/gh-cli/get-sub-issues-summary-of-issue.sh
+++ b/gh-cli/get-sub-issues-summary-of-issue.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-# Gets the sub-issue summary of an issue
+# Gets the sub-issues summary of an issue
 
 if [ -z "$3" ]; then
   echo "Usage: $0 <org> <repo> <issue-number>"
-  echo "Example: ./get-sub-issues-of-issue.sh joshjohanning-org migrating-ado-to-gh-issues-v2 5"
+  echo "Example: ./get-sub-issues-summary-of-issue.sh joshjohanning-org migrating-ado-to-gh-issues-v2 5"
   exit 1
 fi
 


### PR DESCRIPTION
Changes to script names and documentation:

* [`gh-cli/README.md`](diffhunk://#diff-9ec2a7e2e655724844893270790b168184c962e7b1ac9fe5dd0c32783cff7fd1L1099-R1106): Removed the entry for `get-sub-issue-summary-of-issue.sh` and added an entry for `get-sub-issues-summary-of-issue.sh` to correct the script name and description.
* [`gh-cli/get-sub-issues-summary-of-issue.sh`](diffhunk://#diff-f8f1698f55cf7e846e22d77204b7aa186f6ae1c5dc1ff265508ed0d90d5e8a67L3-R7): Renamed the script from `get-sub-issue-summary-of-issue.sh` to `get-sub-issues-summary-of-issue.sh` and updated the usage example in the script comments to reflect the new name.