### PR TITLE
feat: add script to add all repository users to a project

### DIFF
--- a/gh-cli/README.md
+++ b/gh-cli/README.md
@@ -69,6 +69,12 @@ See the [docs](https://cli.github.com/manual/gh_auth_login) for further informat
 
 Adds all members of an organization to a team.
 
+### add-all-users-in-repository-to-project.sh
+
+Adds all users who are direct members of the repository to a ProjectV2 with a given role.
+
+Requires: `./add-user-to-project.sh`
+
 ### add-branch-protection-status-checks.sh
 
 Adds a status check to the branch protection status check contexts.

--- a/gh-cli/add-all-users-in-repository-to-project.sh
+++ b/gh-cli/add-all-users-in-repository-to-project.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+# Adds a all users in a repository to a ProjectV2
+
+# needs: gh auth login -s project
+# needs: ./add-user-to-project.sh
+
+function print_usage {
+  echo "Usage: $0 <organization> <repository> <project-number> <role>"
+  echo "Example: ./add-all-users-in-repository-to-project.sh joshjohanning-org my-repo 1234 WRITER"
+  echo "Valid roles: ADMIN, WRITER, READER, NONE"
+  exit 1
+}
+
+if [ -z "$4" ]; then
+  print_usage
+fi
+
+organization="$1"
+repository="$2"
+project_number="$3"
+role=$(echo "$4" | tr '[:lower:]' '[:upper:]')
+
+case "$role" in
+  "ADMIN" | "WRITER" | "READER" | "NONE")
+    ;;
+  *)
+    print_usage
+    ;;
+esac
+
+# get list of directly added users in a repository
+users=$(gh api graphql --paginate -f owner="$organization" -f repo="$repository" -f query='
+query($owner: String!, $repo: String!, $endCursor:String) {
+  repository(owner: $owner, name: $repo) {
+    collaborators(first: 100, affiliation: DIRECT, after:$endCursor) {
+      edges {
+        node {
+          login
+          id
+        }
+      }
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+    }
+  }
+}
+' --jq '.data.repository.collaborators.edges[].node')
+
+# for each user, add them to the project
+for user in $users; do
+  user_login=$(echo $user | jq -r '.login')
+  echo "Adding $user_login to project $project_id with role $role"
+  ./add-user-to-project.sh $organization $repository $project_number $user_login $role
+done


### PR DESCRIPTION
New Script and Documentation:

* [`gh-cli/add-all-users-in-repository-to-project.sh`](diffhunk://#diff-07e35575818c40c953a9eba23a9ad018d887d3d7ab86a0798d14d687cfe2cc5eR1-R57): Added a new script to add all users who are direct members of a repository to a ProjectV2 with a specified role. The script includes usage instructions and handles user roles.
* [`gh-cli/README.md`](diffhunk://#diff-9ec2a7e2e655724844893270790b168184c962e7b1ac9fe5dd0c32783cff7fd1R72-R77): Updated the README to include information about the new `add-all-users-in-repository-to-project.sh` script, detailing its purpose and requirements.
