### PR TITLE
fix: add a small sleep to avoid rate limiting

### DIFF
--- a/gh-cli/get-actions-usage-in-organization.sh
+++ b/gh-cli/get-actions-usage-in-organization.sh
@@ -157,6 +157,9 @@ actions=""
 repos_without_dependency_graph=()
 
 for repo in $repos; do
+    # Add a small delay to avoid rate limiting
+    sleep 1
+
     # Try to get SBOM data - if it fails, dependency graph is likely disabled
     sbom_data=$(gh api repos/$repo/dependency-graph/sbom --jq '.sbom.packages[].externalRefs.[0].referenceLocator' 2>&1)
     


### PR DESCRIPTION
* Added a one-second delay (`sleep 1`) before each API call in the repository loop to reduce the likelihood of rate limiting issues.