### PR TITLE
fix: ensure pipefail is set for linting commands in workflow

### DIFF
--- a/.github/workflows/lint-readme.yml
+++ b/.github/workflows/lint-readme.yml
@@ -21,7 +21,9 @@ jobs:
 
       - name: Lint ./gh-cli/README.md
         id: lint
-        run: node ./.github/scripts/lint-readme.js | tee gh-cli-readme-lint-results.txt
+        run: |
+          set -o pipefail
+          node ./.github/scripts/lint-readme.js | tee gh-cli-readme-lint-results.txt
 
       - name: Upload lint results
         if: steps.lint.outcome == 'failure' || steps.lint.outcome == 'success'
@@ -42,7 +44,9 @@ jobs:
 
       - name: Lint ./scripts/README.md
         id: lint
-        run: node ./.github/scripts/lint-readme.js ./scripts '##' '# scripts' | tee scripts-readme-lint-results.txt
+        run: |
+          set -o pipefail
+          node ./.github/scripts/lint-readme.js ./scripts '##' '# scripts' | tee scripts-readme-lint-results.txt
 
       - name: Upload lint results
         if: steps.lint.outcome == 'failure' || steps.lint.outcome == 'success'


### PR DESCRIPTION
* Workflow reliability improvements:
  * Added `set -o pipefail` to the linting steps in `lint-readme.yml` to ensure that the workflow fails if either the linting script or the `tee` command fails. [[1]](diffhunk://#diff-5a654531adf63d6b05f6c7f5a33ca68a2374c954cfbc9a560dd893f8c3f0872cL24-R26) [[2]](diffhunk://#diff-5a654531adf63d6b05f6c7f5a33ca68a2374c954cfbc9a560dd893f8c3f0872cL45-R49)