### PR TITLE
fix: ensure linting commands do not fail the workflow by adding '|| true'

### DIFF
--- a/.github/workflows/lint-readme.yml
+++ b/.github/workflows/lint-readme.yml
@@ -23,7 +23,7 @@ jobs:
         id: lint
         run: |
           set -o pipefail
-          node ./.github/scripts/lint-readme.js | tee gh-cli-readme-lint-results.txt
+          node ./.github/scripts/lint-readme.js | tee gh-cli-readme-lint-results.txt || true
 
       - name: Upload lint results
         if: steps.lint.outcome == 'failure' || steps.lint.outcome == 'success'
@@ -46,7 +46,7 @@ jobs:
         id: lint
         run: |
           set -o pipefail
-          node ./.github/scripts/lint-readme.js ./scripts '##' '# scripts' | tee scripts-readme-lint-results.txt
+          node ./.github/scripts/lint-readme.js ./scripts '##' '# scripts' | tee scripts-readme-lint-results.txt || true
 
       - name: Upload lint results
         if: steps.lint.outcome == 'failure' || steps.lint.outcome == 'success'


### PR DESCRIPTION
* The `node ./.github/scripts/lint-readme.js` commands in `.github/workflows/lint-readme.yml` have been updated to append `|| true`, so the workflow continues even if linting fails. [[1]](diffhunk://#diff-5a654531adf63d6b05f6c7f5a33ca68a2374c954cfbc9a560dd893f8c3f0872cL26-R26) [[2]](diffhunk://#diff-5a654531adf63d6b05f6c7f5a33ca68a2374c954cfbc9a560dd893f8c3f0872cL49-R49)